### PR TITLE
Allow SF_VIRTUAL_IO in SndfileHandle.

### DIFF
--- a/src/sndfile.hh
+++ b/src/sndfile.hh
@@ -79,6 +79,8 @@ class SndfileHandle
 							int format = 0, int channels = 0, int samplerate = 0) ;
 			SndfileHandle (int fd, bool close_desc, int mode = SFM_READ,
 							int format = 0, int channels = 0, int samplerate = 0) ;
+			SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mode = SFM_READ,
+							int format = 0, int channels = 0, int samplerate = 0) ;
 
 #ifdef ENABLE_SNDFILE_WINDOWS_PROTOTYPES
 			SndfileHandle (LPCWSTR wpath, int mode = SFM_READ,
@@ -228,6 +230,28 @@ SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int ch
 
 	return ;
 } /* SndfileHandle fd constructor */
+
+inline
+SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mode, int fmt, int chans, int srate)
+: p (NULL)
+{
+	p = new (std::nothrow) SNDFILE_ref () ;
+
+	if (p != NULL)
+	{	p->ref = 1 ;
+
+		p->sfinfo.frames = 0 ;
+		p->sfinfo.channels = chans ;
+		p->sfinfo.format = fmt ;
+		p->sfinfo.samplerate = srate ;
+		p->sfinfo.sections = 0 ;
+		p->sfinfo.seekable = 0 ;
+
+		p->sf = sf_open_virtual(&sfvirtual, mode, &p->sfinfo, user_data) ;
+		} ;
+
+	return ;
+} /* SndfileHandle std::string constructor */
 
 inline
 SndfileHandle::~SndfileHandle (void)


### PR DESCRIPTION
This is an extremely simple patch that exposes sf_open_virtual to the lightweight c++ wrapper.
