### PR TITLE
doc/FAQ.html : Remove HTML tag fragment.

### DIFF
--- a/doc/FAQ.html
+++ b/doc/FAQ.html
@@ -389,7 +389,7 @@ is the risk of breaking something that currently works.
 </B></H2>
 
 <P>
-An <tt>item</tt>tt> is a single sample of the data type you are reading; ie a
+An <tt>item</tt> is a single sample of the data type you are reading; ie a
 single <tt>short</tt> value for <tt>sf_read_short</tt> or a single <tt>float</tt>
 for <tt>sf_read_float</tt>.
 </P>


### PR DESCRIPTION
Trivial fix: `</tt>tt>` which should be just `</tt>`.
