### PR TITLE
Use the PKG_INSTALLDIR macro

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,6 @@ EXTRA_DIST = libsndfile.spec.in sndfile.pc.in
 
 CLEANFILES = *~
 
-pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = sndfile.pc
 
 m4datadir = $(datadir)/aclocal

--- a/configure.ac
+++ b/configure.ac
@@ -301,6 +301,7 @@ EXTERNAL_LIBS=""
 
 # Check for pkg-config outside the if statement.
 PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
 
 if test -n "$PKG_CONFIG" ; then
 	if test x$enable_external_libs = xno ; then


### PR DESCRIPTION
Use the PKG_INSTALLDIR macro instead of defining pkgconfigdir. This
add a configure switch that allows changing where the .pc file goes.

```
modified:   Makefile.am
modified:   configure.ac
```
