### PR TITLE
Properly initialize SF_INFO in example programs

### DIFF
--- a/examples/generate.c
+++ b/examples/generate.c
@@ -98,6 +98,8 @@ encode_file (const char *infilename, const char *outfilename, int filetype)
 	k = 16 - strlen (outfilename) ;
 	PUT_DOTS (k) ;
 
+	memset (&sfinfo, 0, sizeof (sfinfo)) ;
+
 	if (! (infile = sf_open (infilename, SFM_READ, &sfinfo)))
 	{	printf ("Error : could not open file : %s\n", infilename) ;
 		puts (sf_strerror (NULL)) ;

--- a/examples/sfprocess.c
+++ b/examples/sfprocess.c
@@ -60,7 +60,7 @@ main (void)
 	*/
 	SNDFILE	*infile, *outfile ;
 
-	/* A pointer to an SF_INFO stutct is passed to sf_open.
+	/* A pointer to an SF_INFO struct is passed to sf_open.
 	** On read, the library fills this struct with information about the file.
 	** On write, the struct must be filled in before calling sf_open.
 	*/
@@ -68,6 +68,10 @@ main (void)
 	int			readcount ;
 	const char	*infilename = "input.wav" ;
 	const char	*outfilename = "output.wav" ;
+
+	/* The SF_INFO struct must be initialized before using it.
+	*/
+	memset (&sfinfo, 0, sizeof (sfinfo)) ;
 
 	/* Here's where we open the input file. We pass sf_open the file name and
 	** a pointer to an SF_INFO struct.

--- a/examples/sndfile-to-text.c
+++ b/examples/sndfile-to-text.c
@@ -101,6 +101,8 @@ main (int argc, char * argv [])
 		return 1 ;
 		} ;
 
+	memset (&sfinfo, 0, sizeof (sfinfo)) ;
+
 	if ((infile = sf_open (infilename, SFM_READ, &sfinfo)) == NULL)
 	{	printf ("Not able to open input file %s.\n", infilename) ;
 		puts (sf_strerror (NULL)) ;


### PR DESCRIPTION
Some of the example programs (examples/generate.c, examples/sfprocess.c, examples/sndfile-to-text.c) didn't initialize the SF_INFO structure to zero before using it, leading to undefined behaviour. Add a memset() to fix this.
