### PR TITLE
A clean patch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -614,11 +614,12 @@ AC_CONFIG_FILES([ \
 	src/version-metadata.rc tests/test_wrapper.sh tests/pedantic-header-test.sh \
 	doc/libsndfile.css build-test-tarball.mk libsndfile.spec sndfile.pc \
 	src/sndfile.h \
+	echo-install-dirs
 	])
 AC_OUTPUT
 
 # Make sure these are executable.
-chmod u+x tests/test_wrapper.sh build-test-tarball.mk
+chmod u+x tests/test_wrapper.sh build-test-tarball.mk echo-install-dirs
 
 #====================================================================================
 
@@ -660,29 +661,7 @@ if test x$ac_cv_c_compiler_gnu = xyes ; then
 		fi
 	fi
 
-if test $libdir = "\${exec_prefix}/lib" ; then
-	libdir="$prefix/lib"
-	fi
-
-if test $bindir = "\${exec_prefix}/bin" ; then
-	bindir="$prefix/bin"
-	fi
-
-AC_MSG_RESULT([[
-  Installation directories :
-
-    Library directory : ................... $libdir
-    Program directory : ................... $bindir
-    Pkgconfig directory : ................. $libdir/pkgconfig
-    HTML docs directory : ................. $htmldocdir
-]])
-
-if test x$prefix != "x/usr" ; then
-	echo "Compiling some other packages against libsndfile may require"
-	echo "the addition of '$libdir/pkgconfig' to the"
-	echo "PKG_CONFIG_PATH environment variable."
-	echo
-	fi
+(./echo-install-dirs)
 
 (cd src && make genfiles)
 (cd tests && make genfiles)

--- a/echo-install-dirs.in
+++ b/echo-install-dirs.in
@@ -1,0 +1,25 @@
+#!/bin/sh
+# @configure_input@
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+bindir=@bindir@
+pkgconfigdir=@pkgconfigdir@
+datadir=@datadir@
+datarootdir=@datarootdir@
+docdir=@docdir@
+htmldir=@htmldir@
+
+echo "
+  Installation directories :
+
+    Library directory : ................... $libdir
+    Program directory : ................... $bindir
+    Pkgconfig directory : ................. $pkgconfigdir
+    HTML docs directory : ................. $htmldir
+"
+echo "Compiling some other packages against libsndfile may require"
+echo "the addition of '$pkgconfigdir' to the"
+echo "PKG_CONFIG_PATH environment variable."
+echo


### PR DESCRIPTION
Now it should be much cleaner. The commit aims to remove the test from configure.ac and move the printing to the echo-install-dirs script which can print out the paths without tests. I think this solution is more bullet proof.

Also, the printing of the message about the pkgconfig path is made unconditional because it is easier as we don't know what other paths the user is installing to. It could be made conditional again if you think that is better.
