### PR TITLE
Replace `echo -n` with `printf` and fix a message typo in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ test -z "$srcdir" && srcdir=.
 cd "$srcdir"
 DIE=0
 
-echo -n "checking for autogen ... "
+printf "checking for autogen ... "
 result="yes"
 (autogen --version) < /dev/null > /dev/null 2>&1 || {
         echo
@@ -25,7 +25,7 @@ result="yes"
 }
 echo $result
 
-echo -n "checking for autoconf ... "
+printf "checking for autoconf ... "
 result="yes"
 (autoconf --version) < /dev/null > /dev/null 2>&1 || {
         echo
@@ -49,7 +49,7 @@ if test -r Makefile.am; then
     AM_NEEDED=""
   fi
   if test -z $AM_NEEDED; then
-    echo -n "checking for automake ... "
+    printf "checking for automake ... "
     AUTOMAKE=automake
     ACLOCAL=aclocal
     if ($AUTOMAKE --version < /dev/null > /dev/null 2>&1); then
@@ -59,7 +59,7 @@ if test -r Makefile.am; then
       AUTOMAKE=
     fi
   else
-    echo -n "checking for automake $AM_NEEDED or later ... "
+    printf "checking for automake $AM_NEEDED or later ... "
     majneeded=`echo $AM_NEEDED | $VERSIONMKMAJ`
     minneeded=`echo $AM_NEEDED | $VERSIONMKMIN`
     for am in automake-$AM_NEEDED automake$AM_NEEDED \
@@ -75,7 +75,7 @@ if test -r Makefile.am; then
       fi
     done
     test -z $AUTOMAKE &&  echo "no"
-    echo -n "checking for aclocal $AM_NEEDED or later ... "
+    printf "checking for aclocal $AM_NEEDED or later ... "
     for ac in aclocal-$AM_NEEDED aclocal$AM_NEEDED \
 	aclocal aclocal-1.7 aclocal-1.8 aclocal-1.9 aclocal-1.10; do
       ($ac --version < /dev/null > /dev/null 2>&1) || continue
@@ -99,7 +99,7 @@ if test -r Makefile.am; then
   }
 fi
 
-echo -n "checking for libtool ... "
+printf "checking for libtool ... "
 for LIBTOOLIZE in libtoolize glibtoolize nope; do
   ($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 && break
 done
@@ -118,7 +118,7 @@ fi
 	DIE=1
 }
 
-echo -n "checking for pkg-config ... "
+printf "checking for pkg-config ... "
 result="yes"
 (pkg-config --version) < /dev/null > /dev/null 2>&1 || {
         echo
@@ -130,7 +130,7 @@ result="yes"
 echo $result
 
 
-echo -n "checking for python ... "
+printf "checking for python ... "
 result="yes"
 (python --version) < /dev/null > /dev/null 2>&1 || {
         echo
@@ -147,7 +147,7 @@ if test "$DIE" -eq 1; then
 fi
 
 if test ! -d Cfg ; then
-	echo "Createing 'Cfg' directory."
+	echo "Creating 'Cfg' directory."
 	mkdir Cfg
 fi
 


### PR DESCRIPTION
`echo -n` is not standardized and does not work as expected on POSIX-compliant operating systems such as Mac OS X 10.5 and later.

Output before:

```
-n checking for autogen ... 
yes
-n checking for autoconf ... 
yes
-n checking for automake ... 
yes
-n checking for libtool ... 
glibtoolize
-n checking for pkg-config ... 
yes
-n checking for python ... 
yes
Createing 'Cfg' directory.
```

Output after:

```
checking for autogen ... yes
checking for autoconf ... yes
checking for automake ... yes
checking for libtool ... glibtoolize
checking for pkg-config ... yes
checking for python ... yes
Creating 'Cfg' directory.
```
