### PR TITLE
Added support for building in a separate directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,22 +537,22 @@ if test x$ac_cv_c_compiler_gnu = xyes ; then
 			# System headers on these systems are broken.
 			temp_CFLAGS=`echo $CFLAGS | $SED "s/-Wall -pedantic//" | $SED "s/-Wshadow//" | $SED "s/-Waggregate-return//"`
 			CFLAGS=$temp_CFLAGS
-			SHLIB_VERSION_ARG="-Wl,-exported_symbols_list -Wl,\$(srcdir)/Symbols.darwin"
+			SHLIB_VERSION_ARG="-Wl,-exported_symbols_list -Wl,\$(builddir)/Symbols.darwin"
 			;;
 		linux*|kfreebsd*-gnu*|gnu*)
-			SHLIB_VERSION_ARG="-Wl,--version-script=\$(srcdir)/Symbols.gnu-binutils"
+			SHLIB_VERSION_ARG="-Wl,--version-script=\$(builddir)/Symbols.gnu-binutils"
 			;;
 		mingw*)
 			# Linker flag '-Wl,--out-implib' does not work with mingw cross compiler
 			# so we don't use it here.
-			SHLIB_VERSION_ARG="-Wl,\$(srcdir)/libsndfile-1.def"
+			SHLIB_VERSION_ARG="-Wl,\$(builddir)/libsndfile-1.def"
 			win32_target_dll=1
 			if test x"$enable_shared" = xno ; then
 				win32_target_dll=0
 				fi
 			;;
 		os2*)
-			SHLIB_VERSION_ARG="-Wl,-export-symbols \$(srcdir)/Symbols.os2"
+			SHLIB_VERSION_ARG="-Wl,-export-symbols \$(builddir)/Symbols.os2"
 			;;
 		*)
 			;;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -85,9 +85,9 @@ G72x_g72x_test_SOURCES = G72x/g72x_test.c
 G72x_g72x_test_LDADD = G72x/libg72x.la
 
 test_endswap.c: test_endswap.def test_endswap.tpl
-	autogen --writable test_endswap.def
+	cd $(srcdir) && autogen --writable test_endswap.def && cd $(abs_builddir)
 
-genfiles : test_endswap.c $(SYMBOL_FILES)
+genfiles : $(SYMBOL_FILES) test_endswap.c
 
 check :
 	@if [ -x /usr/bin/python ]; then $(srcdir)/binheader_writef_check.py $(srcdir)/*.c ; fi
@@ -103,19 +103,19 @@ checkprograms : $(check_PROGRAMS)
 # end user to create these files.
 
 Symbols.gnu-binutils: create_symbols_file.py
-	python create_symbols_file.py linux $(VERSION) > $@
+	python $(srcdir)/create_symbols_file.py linux $(VERSION) > $@
 
 Symbols.darwin: create_symbols_file.py
-	python create_symbols_file.py darwin $(VERSION) > $@
+	python $(srcdir)/create_symbols_file.py darwin $(VERSION) > $@
 
 libsndfile-1.def: create_symbols_file.py
-	python create_symbols_file.py win32 $(VERSION) > $@
+	python $(srcdir)/create_symbols_file.py win32 $(VERSION) > $@
 
 Symbols.os2: create_symbols_file.py
-	python create_symbols_file.py os2 $(VERSION) > $@
+	python $(srcdir)/create_symbols_file.py os2 $(VERSION) > $@
 
 Symbols.static: create_symbols_file.py
-	python create_symbols_file.py static $(VERSION) > $@
+	python $(srcdir)/create_symbols_file.py static $(VERSION) > $@
 
 # Fake dependancy to force the creation of these files.
 sndfile.o : $(SYMBOL_FILES)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -186,31 +186,31 @@ scale_clip_test_LDADD = $(top_builddir)/src/libsndfile.la
 #===============================================================================
 
 write_read_test.c: write_read_test.def write_read_test.tpl
-	autogen --writable write_read_test.def
+	cd $(srcdir) && autogen --writable write_read_test.def && cd $(abs_builddir)
 
 pcm_test.c: pcm_test.def pcm_test.tpl
-	autogen --writable pcm_test.def
+	cd $(srcdir) && autogen --writable pcm_test.def && cd $(abs_builddir)
 
 header_test.c: header_test.def header_test.tpl
-	autogen --writable header_test.def
+	cd $(srcdir) && autogen --writable header_test.def && cd $(abs_builddir)
 
 utils.c utils.h : utils.def utils.tpl
-	autogen --writable utils.def
+	cd $(srcdir) && autogen --writable utils.def && cd $(abs_builddir)
 
 scale_clip_test.c: scale_clip_test.def scale_clip_test.tpl
-	autogen --writable scale_clip_test.def
+	cd $(srcdir) && autogen --writable scale_clip_test.def && cd $(abs_builddir)
 
 pipe_test.c: pipe_test.def pipe_test.tpl
-	autogen --writable pipe_test.def
+	cd $(srcdir) && autogen --writable pipe_test.def && cd $(abs_builddir)
 
 rdwr_test.c: rdwr_test.def rdwr_test.tpl
-	autogen --writable rdwr_test.def
+	cd $(srcdir) && autogen --writable rdwr_test.def && cd $(abs_builddir)
 
 floating_point_test.c: floating_point_test.def floating_point_test.tpl
-	autogen --writable floating_point_test.def
+	cd $(srcdir) && autogen --writable floating_point_test.def && cd $(abs_builddir)
 
 benchmark.c: benchmark.def benchmark.tpl
-	autogen --writable benchmark.def
+	cd $(srcdir) && autogen --writable benchmark.def && cd $(abs_builddir)
 
 genfiles : write_read_test.c pcm_test.c header_test.c utils.c \
 		scale_clip_test.c pipe_test.c floating_point_test.c rdwr_test.c \


### PR DESCRIPTION
Currently, only building in the source tree succeeds. This change fixes the tests and symbols paths.
