### PR TITLE
Fix decoding of IMA4 AIFF-C, closes #2

### DIFF
--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -269,7 +269,8 @@ count ++ ;
 	{	blockdata = pima->block + chan * 34 ;
 		sampledata = pima->samples + chan ;
 
-		predictor = (blockdata [0] << 8) | (blockdata [1] & 0x80) ;
+		/* Sign-extend from 16 bits to 32. */
+		predictor = (int) (short) ((blockdata [0] << 8) | (blockdata [1] & 0x80)) ;
 
 		stepindx = blockdata [1] & 0x7F ;
 		stepindx = clamp_ima_step_index (stepindx) ;


### PR DESCRIPTION
This fixes a bug in decoding IMA4-compressed AIFF-C files. The predictor value used to decode each block is a 16-bit signed number stored in an `int` (because it can go outside the 16-bit range and is then clamped back into it), but it was not being sign-extended correctly, so a negative predictor became a positive `int`.

This is probably not my last commit in this area -- I've been dealing with this format for a bit and it appears Apple changed a detail of the decoding algorithm at some point in a sort-of-backwards-compatible way (see my contribution at http://sed.free.fr/aifc2wav.html), but this gets the "original" algorithm working.
