### PR TITLE
Seeking for IMA4 AIFF-C files

### DIFF
--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -77,7 +77,8 @@ static sf_count_t ima_write_i (SF_PRIVATE *psf, const int *ptr, sf_count_t len) 
 static sf_count_t ima_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len) ;
 static sf_count_t ima_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len) ;
 
-static sf_count_t	ima_seek	(SF_PRIVATE *psf, int mode, sf_count_t offset) ;
+static sf_count_t aiff_ima_seek		(SF_PRIVATE *psf, int mode, sf_count_t offset) ;
+static sf_count_t wav_w64_ima_seek	(SF_PRIVATE *psf, int mode, sf_count_t offset) ;
 
 static int	ima_close	(SF_PRIVATE *psf) ;
 
@@ -124,7 +125,7 @@ wav_w64_ima_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 			return error ;
 
 	psf->codec_close = ima_close ;
-	psf->seek = ima_seek ;
+	psf->seek = wav_w64_ima_seek ;
 
 	return 0 ;
 } /* wav_w64_ima_init */
@@ -145,6 +146,7 @@ aiff_ima_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 			return error ;
 
 	psf->codec_close = ima_close ;
+	psf->seek = aiff_ima_seek ;
 
 	return 0 ;
 } /* aiff_ima_init */
@@ -710,7 +712,53 @@ ima_read_d (SF_PRIVATE *psf, double *ptr, sf_count_t len)
 } /* ima_read_d */
 
 static sf_count_t
-ima_seek (SF_PRIVATE *psf, int mode, sf_count_t offset)
+aiff_ima_seek (SF_PRIVATE *psf, int mode, sf_count_t offset)
+{	IMA_ADPCM_PRIVATE *pima ;
+	int			newblock, newsample, newblockaiff ;
+
+	if (! psf->codec_data)
+		return 0 ;
+	pima = (IMA_ADPCM_PRIVATE*) psf->codec_data ;
+
+	if (psf->datalength < 0 || psf->dataoffset < 0)
+	{	psf->error = SFE_BAD_SEEK ;
+		return PSF_SEEK_ERROR ;
+		} ;
+
+	if (offset == 0)
+	{	psf_fseek (psf, psf->dataoffset, SEEK_SET) ;
+		pima->blockcount = 0 ;
+		pima->decode_block (psf, pima) ;
+		pima->samplecount = 0 ;
+		return 0 ;
+		} ;
+
+	if (offset < 0 || offset > pima->blocks * pima->samplesperblock)
+	{	psf->error = SFE_BAD_SEEK ;
+		return	PSF_SEEK_ERROR ;
+		} ;
+
+	newblock		= offset / pima->samplesperblock ;
+	newsample		= offset % pima->samplesperblock ;
+	newblockaiff	= newblock * psf->sf.channels ;
+
+	if (mode == SFM_READ)
+	{	psf_fseek (psf, psf->dataoffset + newblockaiff * pima->blocksize, SEEK_SET) ;
+		pima->blockcount = newblockaiff ;
+		pima->decode_block (psf, pima) ;
+		pima->samplecount = newsample ;
+		}
+	else
+	{	/* What to do about write??? */
+		psf->error = SFE_BAD_SEEK ;
+		return	PSF_SEEK_ERROR ;
+		} ;
+
+	return newblock * pima->samplesperblock + newsample ;
+} /* aiff_ima_seek */
+
+static sf_count_t
+wav_w64_ima_seek (SF_PRIVATE *psf, int mode, sf_count_t offset)
 {	IMA_ADPCM_PRIVATE *pima ;
 	int			newblock, newsample ;
 
@@ -752,7 +800,7 @@ ima_seek (SF_PRIVATE *psf, int mode, sf_count_t offset)
 		} ;
 
 	return newblock * pima->samplesperblock + newsample ;
-} /* ima_seek */
+} /* wav_w64_ima_seek */
 
 /*==========================================================================================
 ** IMA ADPCM Write Functions.


### PR DESCRIPTION
This patch allows seeking in IMA4 AIFF-C files. Looking at the existing IMA functions, there's a discrepancy in the AIFF and WAV container versions, which makes this patch kind of hacky.
- `wav_w64_ima_decode_block` does `pima->blockcount ++ ;` so `blockcount` is the number of "block-frames" read, where one block-frame has a block for each channel. This makes more sense in my opinion.
- `aiff_ima_decode_block` does `pima->blockcount += pima->channels ;` so `blockcount` is the number of individual channel blocks read.

Because of this I needed to duplicate the existing `ima_seek` function (which was for WAV) into two slightly different functions. If the above discrepancy is a mistake you want to fix, feel free to reject this pull request and let me know what your plans are.
