### PR TITLE
Opus: Fix preskip on streams with non-zero starting granule positions

### DIFF
--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -1071,7 +1071,7 @@ ogg_opus_read_refill (SF_PRIVATE *psf, OGG_PRIVATE *odata, OPUS_PRIVATE *oopus)
 	** to converge and should be dropped.
 	*/
 	if (oopus->pkt_pos < oopus->u.decode.gp_preskip)
-		oopus->loc = SF_MIN ((oopus->u.decode.gp_preskip - oopus->pkt_pos) / oopus->sr_factor, oopus->len) ;
+		oopus->loc = SF_MIN ((int) (oopus->u.decode.gp_preskip - oopus->pkt_pos) / oopus->sr_factor, oopus->len) ;
 	else
 		oopus->loc = 0 ;
 


### PR DESCRIPTION
Previously header.preskip was compared against pkt_pos, which might have an offset. Introduce gp_preskip, the granule position after the preskip amount, to make things both more explicit and removing a few instances of (gp_start + header.preskip).

~~Possibly related to issue #555.~~