### PR TITLE
Remove CMAKE_OSX_DEPLOYMENT_TARGET which should be set by the consumer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ if (POLICY CMP0091)
 	endif ()
 endif ()
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
-
 project(libsndfile VERSION 1.0.30)
 
 #


### PR DESCRIPTION
Sorry but I had a bad understanding on how to handle CMAKE_OSX_DEPLOYMENT_TARGET at the time of my last PR.