### PR TITLE
SF_BROADCAST_INFO -> SF_LOOP_INFO

### DIFF
--- a/docs/command.md
+++ b/docs/command.md
@@ -1560,7 +1560,7 @@ data
 datasize
 : sizeof (SF_LOOP_INFO)
 
-The SF_BROADCAST_INFO struct is defined in *sndfile.h* as:
+The SF_LOOP_INFO struct is defined in *sndfile.h* as:
 
 ```c
 typedef struct


### PR DESCRIPTION
I believe this fixes an error in the documentation I found Here:
http://www.mega-nerd.com/libsndfile/command.html#SFC_GET_LOOP_INFO