### PR TITLE
Exclude repository-configuration from git-archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,7 @@
 # to native line endings on checkout.
 *.c text
 *.h text
+
+# exclude repository configurations from 'git archive'
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
having a .gitignore file in the git-archives (e.g. like the automated
archives provided by github) is rather annoying if the archive gets
imported in other repositories.

my use-case is the Debian packaging, where we really want to see any files created/modified during the build process.