### PR TITLE
Fixed typo in FindSQLite3.cmake file

### DIFF
--- a/cmake/sqlite/FindSQLite3.cmake
+++ b/cmake/sqlite/FindSQLite3.cmake
@@ -42,8 +42,8 @@ find_package_handle_standard_args (SQLite3
 	)
 
 if (SQLite3_FOUND)
-	set SQLite3_INCLUDE_DIRS ${SQLite3_INCLUDE_DIR})
-	set SQLite3_LIBRARIES ${SQLite3_LIBRARY})
+	set (SQLite3_INCLUDE_DIRS ${SQLite3_INCLUDE_DIR})
+	set (SQLite3_LIBRARIES ${SQLite3_LIBRARY})
 	if (NOT TARGET SQLite::SQLite3)
 		add_library (SQLite::SQLite3 UNKNOWN IMPORTED)
 		set_target_properties (SQLite::SQLite3 PROPERTIES


### PR DESCRIPTION
Adding libsndfile in NDK based android app is failing for this typo.