### PR TITLE
Implement fast SSE2 lrint and lrintf

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
 Unreleased
+  * Implement fast SSE2 optimized psf_lrintf() and psf_lrintf() functions to
+    improve perfomance when libsndfile is built using Visual C++ (especially)
+    and other compilers on x86 and AMD64 platforms.
   * Documentation:
     * Move site to new URL: http://libsndfile.github.io/libsndfile/
     * Convert documentation pages from HTML to Markdown

--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -67,6 +67,7 @@ check_include_file (stdint.h		HAVE_STDINT_H)
 check_include_file (sys/time.h		HAVE_SYS_TIME_H)
 check_include_file (sys/types.h		HAVE_SYS_TYPES_H)
 check_include_file (unistd.h		HAVE_UNISTD_H)
+check_include_file (immintrin.h		HAVE_IMMINTRIN_H)
 
 # Never checked
 # check_include_file (stdlib.h		HAVE_STDLIB_H)

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,7 @@ AC_CHECK_HEADERS([endian.h])
 AC_CHECK_HEADERS([byteswap.h])
 AC_CHECK_HEADERS([locale.h])
 AC_CHECK_HEADERS([sys/time.h])
+AC_CHECK_HEADERS([immintrin.h])
 
 AC_HEADER_SYS_WAIT
 

--- a/src/alaw.c
+++ b/src/alaw.c
@@ -340,9 +340,9 @@ static inline void
 f2alaw_array (const float *ptr, int count, unsigned char *buffer, float normfact)
 {	while (--count >= 0)
 	{	if (ptr [count] >= 0)
-			buffer [count] = alaw_encode [lrintf (normfact * ptr [count])] ;
+			buffer [count] = alaw_encode [psf_lrintf (normfact * ptr [count])] ;
 		else
-			buffer [count] = 0x7F & alaw_encode [- lrintf (normfact * ptr [count])] ;
+			buffer [count] = 0x7F & alaw_encode [- psf_lrintf (normfact * ptr [count])] ;
 		} ;
 } /* f2alaw_array */
 
@@ -352,9 +352,9 @@ d2alaw_array (const double *ptr, int count, unsigned char *buffer, double normfa
 	{	if (!isfinite (ptr [count]))
 			buffer [count] = 0 ;
 		else if (ptr [count] >= 0)
-			buffer [count] = alaw_encode [lrint (normfact * ptr [count])] ;
+			buffer [count] = alaw_encode [psf_lrint (normfact * ptr [count])] ;
 		else
-			buffer [count] = 0x7F & alaw_encode [- lrint (normfact * ptr [count])] ;
+			buffer [count] = 0x7F & alaw_encode [- psf_lrint (normfact * ptr [count])] ;
 		} ;
 } /* d2alaw_array */
 

--- a/src/caf.c
+++ b/src/caf.c
@@ -370,7 +370,7 @@ caf_read_header (SF_PRIVATE *psf)
 		return SFE_MALFORMED_FILE ;
 		} ;
 
-	psf->sf.samplerate = lrint (srate) ;
+	psf->sf.samplerate = psf_lrint (srate) ;
 
 	psf_binheader_readf (psf, "mE44444", &desc.fmt_id, &desc.fmt_flags, &desc.pkt_bytes, &desc.frames_per_packet,
 			&desc.channels_per_frame, &desc.bits_per_chan) ;

--- a/src/common.c
+++ b/src/common.c
@@ -1606,7 +1606,7 @@ psf_f2s_array (const float *src, short *dest, int count, int normalize)
 
 	normfact = normalize ? (1.0 * 0x7FFF) : 1.0 ;
 	while (--count >= 0)
-		dest [count] = lrintf (src [count] * normfact) ;
+		dest [count] = psf_lrintf (src [count] * normfact) ;
 
 	return ;
 } /* psf_f2s_array */
@@ -1628,7 +1628,7 @@ psf_f2s_clip_array (const float *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		dest [count] = lrintf (scaled_value) ;
+		dest [count] = psf_lrintf (scaled_value) ;
 		} ;
 
 	return ;
@@ -1640,7 +1640,7 @@ psf_d2s_array (const double *src, short *dest, int count, int normalize)
 
 	normfact = normalize ? (1.0 * 0x7FFF) : 1.0 ;
 	while (--count >= 0)
-		dest [count] = lrint (src [count] * normfact) ;
+		dest [count] = psf_lrint (src [count] * normfact) ;
 
 	return ;
 } /* psf_f2s_array */
@@ -1662,7 +1662,7 @@ psf_d2s_clip_array (const double *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		dest [count] = lrint (scaled_value) ;
+		dest [count] = psf_lrint (scaled_value) ;
 		} ;
 
 	return ;
@@ -1675,7 +1675,7 @@ psf_f2i_array (const float *src, int *dest, int count, int normalize)
 
 	normfact = normalize ? (1.0 * 0x7FFFFFFF) : 1.0 ;
 	while (--count >= 0)
-		dest [count] = lrintf (src [count] * normfact) ;
+		dest [count] = psf_lrintf (src [count] * normfact) ;
 
 	return ;
 } /* psf_f2i_array */
@@ -1697,7 +1697,7 @@ psf_f2i_clip_array (const float *src, int *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		dest [count] = lrintf (scaled_value) ;
+		dest [count] = psf_lrintf (scaled_value) ;
 		} ;
 
 	return ;
@@ -1709,7 +1709,7 @@ psf_d2i_array (const double *src, int *dest, int count, int normalize)
 
 	normfact = normalize ? (1.0 * 0x7FFFFFFF) : 1.0 ;
 	while (--count >= 0)
-		dest [count] = lrint (src [count] * normfact) ;
+		dest [count] = psf_lrint (src [count] * normfact) ;
 
 	return ;
 } /* psf_f2i_array */
@@ -1731,7 +1731,7 @@ psf_d2i_clip_array (const double *src, int *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		dest [count] = lrint (scaled_value) ;
+		dest [count] = psf_lrint (scaled_value) ;
 		} ;
 
 	return ;

--- a/src/common.h
+++ b/src/common.h
@@ -37,6 +37,10 @@
 #include "sndfile.h"
 #endif
 
+#ifdef USE_SSE2
+#include <immintrin.h>
+#endif
+
 #ifdef __cplusplus
 #error "This code is not designed to be compiled with a C++ compiler."
 #endif
@@ -546,6 +550,8 @@ typedef struct sf_private_tag
 	SF_CHUNK_ITERATOR *	(*next_chunk_iterator)	(struct sf_private_tag*, SF_CHUNK_ITERATOR * iterator) ;
 	int					(*get_chunk_size)	(struct sf_private_tag*, const SF_CHUNK_ITERATOR * iterator, SF_CHUNK_INFO * chunk_info) ;
 	int					(*get_chunk_data)	(struct sf_private_tag*, const SF_CHUNK_ITERATOR * iterator, SF_CHUNK_INFO * chunk_info) ;
+
+	int cpu_flags ;
 } SF_PRIVATE ;
 
 
@@ -997,6 +1003,28 @@ psf_strlcpy (char *dest, size_t n, const char *src)
 {	strncpy (dest, src, n - 1) ;
 	dest [n - 1] = 0 ;
 } /* psf_strlcpy */
+
+/*------------------------------------------------------------------------------------
+** SIMD optimized math functions.
+*/
+
+static inline int psf_lrintf (float x)
+{
+	#ifdef USE_SSE2
+ 		return _mm_cvtss_si32 (_mm_load_ss (&x)) ;
+	#else
+		return lrintf (x) ;
+	#endif
+} /* psf_lrintf */
+
+static inline int psf_lrint (double x)
+{
+	#ifdef USE_SSE2
+ 		return _mm_cvtsd_si32 (_mm_load_sd (&x)) ;
+	#else
+		return lrint (x) ;
+	#endif
+} /* psf_lrintf */
 
 /*------------------------------------------------------------------------------------
 ** Other helper functions.

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -172,6 +172,9 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine01 HAVE_UNISTD_H
 
+/* Define to 1 if you have the <immintrin.h> header file. */
+#cmakedefine01 HAVE_IMMINTRIN_H
+
 /* Define to 1 if you have the `vsnprintf' function. */
 #cmakedefine01 HAVE_VSNPRINTF
 

--- a/src/double64.c
+++ b/src/double64.c
@@ -368,7 +368,7 @@ double64_be_write (double in, unsigned char *out)
 	out [1] |= (exponent << 4) & 0xF0 ;
 
 	in *= 0x20000000 ;
-	mantissa = lrint (floor (in)) ;
+	mantissa = psf_lrint (floor (in)) ;
 
 	out [1] |= (mantissa >> 24) & 0xF ;
 	out [2] = (mantissa >> 16) & 0xFF ;
@@ -377,7 +377,7 @@ double64_be_write (double in, unsigned char *out)
 
 	in = fmod (in, 1.0) ;
 	in *= 0x1000000 ;
-	mantissa = lrint (floor (in)) ;
+	mantissa = psf_lrint (floor (in)) ;
 
 	out [5] = (mantissa >> 16) & 0xFF ;
 	out [6] = (mantissa >> 8) & 0xFF ;
@@ -408,7 +408,7 @@ double64_le_write (double in, unsigned char *out)
 	out [6] |= (exponent << 4) & 0xF0 ;
 
 	in *= 0x20000000 ;
-	mantissa = lrint (floor (in)) ;
+	mantissa = psf_lrint (floor (in)) ;
 
 	out [6] |= (mantissa >> 24) & 0xF ;
 	out [5] = (mantissa >> 16) & 0xFF ;
@@ -417,7 +417,7 @@ double64_le_write (double in, unsigned char *out)
 
 	in = fmod (in, 1.0) ;
 	in *= 0x1000000 ;
-	mantissa = lrint (floor (in)) ;
+	mantissa = psf_lrint (floor (in)) ;
 
 	out [2] = (mantissa >> 16) & 0xFF ;
 	out [1] = (mantissa >> 8) & 0xFF ;
@@ -487,7 +487,7 @@ double64_get_capability	(SF_PRIVATE *psf)
 static void
 d2s_array (const double *src, int count, short *dest, double scale)
 {	while (--count >= 0)
-	{	dest [count] = lrint (scale * src [count]) ;
+	{	dest [count] = psf_lrint (scale * src [count]) ;
 		} ;
 } /* d2s_array */
 
@@ -501,14 +501,14 @@ d2s_clip_array (const double *src, int count, short *dest, double scale)
 		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < -32768.0)
 			dest [count] = SHRT_MIN ;
 		else
-			dest [count] = lrint (tmp) ;
+			dest [count] = psf_lrint (tmp) ;
 		} ;
 } /* d2s_clip_array */
 
 static void
 d2i_array (const double *src, int count, int *dest, double scale)
 {	while (--count >= 0)
-	{	dest [count] = lrint (scale * src [count]) ;
+	{	dest [count] = psf_lrint (scale * src [count]) ;
 		} ;
 } /* d2i_array */
 
@@ -522,7 +522,7 @@ d2i_clip_array (const double *src, int count, int *dest, double scale)
 		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < (-1.0 * INT_MAX))
 			dest [count] = INT_MIN ;
 		else
-			dest [count] = lrint (tmp) ;
+			dest [count] = psf_lrint (tmp) ;
 		} ;
 } /* d2i_clip_array */
 

--- a/src/dwvw.c
+++ b/src/dwvw.c
@@ -628,7 +628,7 @@ dwvw_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			iptr [k] = lrintf (normfact * ptr [total + k]) ;
+			iptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = dwvw_encode_data (psf, pdwvw, iptr, writecount) ;
 
 		total += count ;
@@ -660,7 +660,7 @@ dwvw_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			iptr [k] = lrint (normfact * ptr [total + k]) ;
+			iptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = dwvw_encode_data (psf, pdwvw, iptr, writecount) ;
 
 		total += count ;

--- a/src/flac.c
+++ b/src/flac.c
@@ -881,7 +881,7 @@ flac_command (SF_PRIVATE * psf, int command, void * data, int datasize)
 			*/
 			quality = (*((double *) data)) * 8.0 ;
 			/* Clip range. */
-			pflac->compression = lrint (SF_MAX (0.0, SF_MIN (8.0, quality))) ;
+			pflac->compression = psf_lrint (SF_MAX (0.0, SF_MIN (8.0, quality))) ;
 
 			psf_log_printf (psf, "%s : Setting SFC_SET_COMPRESSION_LEVEL to %u.\n", __func__, pflac->compression) ;
 
@@ -1186,7 +1186,7 @@ f2flac8_clip_array (const float *src, int32_t *dest, int count, int normalize)
 		{	dest [count] = -0x80 ;
 			continue ;
 			} ;
-		dest [count] = lrintf (scaled_value) ;
+		dest [count] = psf_lrintf (scaled_value) ;
 		} ;
 
 	return ;
@@ -1208,7 +1208,7 @@ f2flac16_clip_array (const float *src, int32_t *dest, int count, int normalize)
 		{	dest [count] = -0x8000 ;
 			continue ;
 			} ;
-		dest [count] = lrintf (scaled_value) ;
+		dest [count] = psf_lrintf (scaled_value) ;
 		} ;
 } /* f2flac16_clip_array */
 
@@ -1229,7 +1229,7 @@ f2flac24_clip_array (const float *src, int32_t *dest, int count, int normalize)
 		{	dest [count] = -0x800000 ;
 			continue ;
 			}
-		dest [count] = lrintf (scaled_value) ;
+		dest [count] = psf_lrintf (scaled_value) ;
 		} ;
 
 	return ;
@@ -1240,7 +1240,7 @@ f2flac8_array (const float *src, int32_t *dest, int count, int normalize)
 {	float normfact = normalize ? (1.0 * 0x7F) : 1.0 ;
 
 	while (--count >= 0)
-		dest [count] = lrintf (src [count] * normfact) ;
+		dest [count] = psf_lrintf (src [count] * normfact) ;
 } /* f2flac8_array */
 
 static void
@@ -1248,7 +1248,7 @@ f2flac16_array (const float *src, int32_t *dest, int count, int normalize)
 {	float normfact = normalize ? (1.0 * 0x7FFF) : 1.0 ;
 
 	while (--count >= 0)
-		dest [count] = lrintf (src [count] * normfact) ;
+		dest [count] = psf_lrintf (src [count] * normfact) ;
 } /* f2flac16_array */
 
 static void
@@ -1256,7 +1256,7 @@ f2flac24_array (const float *src, int32_t *dest, int count, int normalize)
 {	float normfact = normalize ? (1.0 * 0x7FFFFF) : 1.0 ;
 
 	while (--count >= 0)
-		dest [count] = lrintf (src [count] * normfact) ;
+		dest [count] = psf_lrintf (src [count] * normfact) ;
 } /* f2flac24_array */
 
 static sf_count_t
@@ -1317,7 +1317,7 @@ d2flac8_clip_array (const double *src, int32_t *dest, int count, int normalize)
 		{	dest [count] = -0x80 ;
 			continue ;
 			} ;
-		dest [count] = lrint (scaled_value) ;
+		dest [count] = psf_lrint (scaled_value) ;
 		} ;
 
 	return ;
@@ -1339,7 +1339,7 @@ d2flac16_clip_array (const double *src, int32_t *dest, int count, int normalize)
 		{	dest [count] = -0x8000 ;
 			continue ;
 			} ;
-		dest [count] = lrint (scaled_value) ;
+		dest [count] = psf_lrint (scaled_value) ;
 		} ;
 
 	return ;
@@ -1361,7 +1361,7 @@ d2flac24_clip_array (const double *src, int32_t *dest, int count, int normalize)
 		{	dest [count] = -0x800000 ;
 			continue ;
 			} ;
-		dest [count] = lrint (scaled_value) ;
+		dest [count] = psf_lrint (scaled_value) ;
 		} ;
 
 	return ;
@@ -1372,7 +1372,7 @@ d2flac8_array (const double *src, int32_t *dest, int count, int normalize)
 {	double normfact = normalize ? (1.0 * 0x7F) : 1.0 ;
 
 	while (--count >= 0)
-		dest [count] = lrint (src [count] * normfact) ;
+		dest [count] = psf_lrint (src [count] * normfact) ;
 } /* d2flac8_array */
 
 static void
@@ -1380,7 +1380,7 @@ d2flac16_array (const double *src, int32_t *dest, int count, int normalize)
 {	double normfact = normalize ? (1.0 * 0x7FFF) : 1.0 ;
 
 	while (--count >= 0)
-		dest [count] = lrint (src [count] * normfact) ;
+		dest [count] = psf_lrint (src [count] * normfact) ;
 } /* d2flac16_array */
 
 static void
@@ -1388,7 +1388,7 @@ d2flac24_array (const double *src, int32_t *dest, int count, int normalize)
 {	double normfact = normalize ? (1.0 * 0x7FFFFF) : 1.0 ;
 
 	while (--count >= 0)
-		dest [count] = lrint (src [count] * normfact) ;
+		dest [count] = psf_lrint (src [count] * normfact) ;
 } /* d2flac24_array */
 
 static sf_count_t

--- a/src/float32.c
+++ b/src/float32.c
@@ -438,7 +438,7 @@ static void
 f2s_array (const float *src, int count, short *dest, float scale)
 {
 	while (--count >= 0)
-	{	dest [count] = lrintf (scale * src [count]) ;
+	{	dest [count] = psf_lrintf (scale * src [count]) ;
 		} ;
 } /* f2s_array */
 
@@ -452,14 +452,14 @@ f2s_clip_array (const float *src, int count, short *dest, float scale)
 		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < -32768.0)
 			dest [count] = SHRT_MIN ;
 		else
-			dest [count] = lrintf (tmp) ;
+			dest [count] = psf_lrintf (tmp) ;
 		} ;
 } /* f2s_clip_array */
 
 static inline void
 f2i_array (const float *src, int count, int *dest, float scale)
 {	while (--count >= 0)
-	{	dest [count] = lrintf (scale * src [count]) ;
+	{	dest [count] = psf_lrintf (scale * src [count]) ;
 		} ;
 } /* f2i_array */
 
@@ -473,7 +473,7 @@ f2i_clip_array (const float *src, int count, int *dest, float scale)
 		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < (-1.0 * INT_MAX))
 			dest [count] = INT_MIN ;
 		else
-			dest [count] = lrintf (tmp) ;
+			dest [count] = psf_lrintf (tmp) ;
 		} ;
 } /* f2i_clip_array */
 

--- a/src/g72x.c
+++ b/src/g72x.c
@@ -538,7 +538,7 @@ g72x_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrintf (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = g72x_write_block (psf, pg72x, sptr, writecount) ;
 
 		total += count ;
@@ -570,7 +570,7 @@ g72x_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrint (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = g72x_write_block (psf, pg72x, sptr, writecount) ;
 
 		total += count ;

--- a/src/gsm610.c
+++ b/src/gsm610.c
@@ -563,7 +563,7 @@ gsm610_write_f	(SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrintf (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = gsm610_write_block (psf, pgsm610, sptr, writecount) ;
 
 		total += count ;
@@ -594,7 +594,7 @@ gsm610_write_d	(SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrint (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = gsm610_write_block (psf, pgsm610, sptr, writecount) ;
 
 		total += count ;

--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -959,7 +959,7 @@ ima_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : (int) len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrintf (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = ima_write_block (psf, pima, sptr, writecount) ;
 		total += count ;
 		len -= writecount ;
@@ -990,7 +990,7 @@ ima_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : (int) len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrint (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = ima_write_block (psf, pima, sptr, writecount) ;
 		total += count ;
 		len -= writecount ;

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -248,7 +248,7 @@ mat4_read_header (SF_PRIVATE *psf)
 	if ((rows != 1) || (cols != 1))
 		return SFE_MAT4_NO_SAMPLERATE ;
 
-	psf->sf.samplerate = lrint (value) ;
+	psf->sf.samplerate = psf_lrint (value) ;
 
 	/* Now write out the audio data. */
 

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -370,7 +370,7 @@ mat5_read_header (SF_PRIVATE *psf)
 					snprintf (name, sizeof (name), "%f\n", samplerate) ;
 					psf_log_printf (psf, "    Val  : %s\n", name) ;
 
-					psf->sf.samplerate = lrint (samplerate) ;
+					psf->sf.samplerate = psf_lrint (samplerate) ;
 					} ;
 				break ;
 

--- a/src/ms_adpcm.c
+++ b/src/ms_adpcm.c
@@ -731,7 +731,7 @@ msadpcm_write_f	(SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrintf (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = msadpcm_write_block (psf, pms, sptr, writecount) ;
 		total += count ;
 		len -= writecount ;
@@ -761,7 +761,7 @@ msadpcm_write_d	(SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrint (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = msadpcm_write_block (psf, pms, sptr, writecount) ;
 		total += count ;
 		len -= writecount ;

--- a/src/nms_adpcm.c
+++ b/src/nms_adpcm.c
@@ -978,7 +978,7 @@ nms_adpcm_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrintf (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = nms_adpcm_write_block (psf, pnms, sptr, writecount) ;
 
 		total += count ;
@@ -1010,7 +1010,7 @@ nms_adpcm_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrint (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = nms_adpcm_write_block (psf, pnms, sptr, writecount) ;
 
 		total += count ;

--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -1161,12 +1161,12 @@ ogg_opus_read_s (SF_PRIVATE *psf, short *ptr, sf_count_t len)
 			if (psf->float_int_mult)
 			{	float inverse = 1.0 / psf->float_max ;
 				for ( ; i < total ; i++)
-				{	ptr [i] = lrintf (((*(iptr++)) * inverse) * 32767.0f) ;
+				{	ptr [i] = psf_lrintf (((*(iptr++)) * inverse) * 32767.0f) ;
 					} ;
 				}
 			else
 			{	for ( ; i < total ; i++)
-				{	ptr [i] = lrintf ((*(iptr++)) * 32767.0f) ;
+				{	ptr [i] = psf_lrintf ((*(iptr++)) * 32767.0f) ;
 					} ;
 				} ;
 			oopus->loc += (readlen / psf->sf.channels) ;
@@ -1198,12 +1198,12 @@ ogg_opus_read_i (SF_PRIVATE *psf, int *ptr, sf_count_t len)
 			if (psf->float_int_mult)
 			{	float inverse = 1.0 / psf->float_max ;
 				for ( ; i < total ; i++)
-				{	ptr [i] = lrintf (((*(iptr++)) * inverse) * 2147483647.0f) ;
+				{	ptr [i] = psf_lrintf (((*(iptr++)) * inverse) * 2147483647.0f) ;
 					}
 				}
 			else
 			{	for ( ; i < total ; i++)
-				{	ptr [i] = lrintf ((*(iptr++)) * 2147483647.0f) ;
+				{	ptr [i] = psf_lrintf ((*(iptr++)) * 2147483647.0f) ;
 					}
 				} ;
 			oopus->loc += (readlen / psf->sf.channels) ;

--- a/src/ogg_vorbis.c
+++ b/src/ogg_vorbis.c
@@ -558,13 +558,13 @@ vorbis_rshort (SF_PRIVATE *psf, int samples, void *vptr, int off, int channels, 
 		float inverse = 1.0 / psf->float_max ;
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-				ptr [i++] = lrintf ((pcm [n][j] * inverse) * 32767.0f) ;
+				ptr [i++] = psf_lrintf ((pcm [n][j] * inverse) * 32767.0f) ;
 	}
 	else
 	{
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-				ptr [i++] = lrintf (pcm [n][j] * 32767.0f) ;
+				ptr [i++] = psf_lrintf (pcm [n][j] * 32767.0f) ;
 	}
 	return i ;
 } /* vorbis_rshort */
@@ -580,13 +580,13 @@ vorbis_rint (SF_PRIVATE *psf, int samples, void *vptr, int off, int channels, fl
 		float inverse = 1.0 / psf->float_max ;
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-				ptr [i++] = lrintf ((pcm [n][j] * inverse) * 2147483647.0f) ;
+				ptr [i++] = psf_lrintf ((pcm [n][j] * inverse) * 2147483647.0f) ;
 	}
 	else
 	{
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-				ptr [i++] = lrintf (pcm [n][j] * 2147483647.0f) ;
+				ptr [i++] = psf_lrintf (pcm [n][j] * 2147483647.0f) ;
 	}
 	return i ;
 } /* vorbis_rint */

--- a/src/paf.c
+++ b/src/paf.c
@@ -774,7 +774,7 @@ paf24_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			iptr [k] = lrintf (normfact * ptr [total + k]) ;
+			iptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = paf24_write (psf, ppaf24, iptr, writecount) ;
 		total += count ;
 		len -= writecount ;
@@ -805,7 +805,7 @@ paf24_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : len ;
 		for (k = 0 ; k < writecount ; k++)
-			iptr [k] = lrint (normfact * ptr [total+k]) ;
+			iptr [k] = psf_lrint (normfact * ptr [total+k]) ;
 		count = paf24_write (psf, ppaf24, iptr, writecount) ;
 		total += count ;
 		len -= writecount ;

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1766,7 +1766,7 @@ f2sc_array (const float *src, signed char *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7F) : 1.0 ;
 
 	while (--count >= 0)
-	{	dest [count] = lrintf (src [count] * normfact) ;
+	{	dest [count] = psf_lrintf (src [count] * normfact) ;
 		} ;
 } /* f2sc_array */
 
@@ -1787,7 +1787,7 @@ f2sc_clip_array (const float *src, signed char *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		dest [count] = lrintf (scaled_value) >> 24 ;
+		dest [count] = psf_lrintf (scaled_value) >> 24 ;
 		} ;
 } /* f2sc_clip_array */
 
@@ -1825,7 +1825,7 @@ f2uc_array	(const float *src, unsigned char *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7F) : 1.0 ;
 
 	while (--count >= 0)
-	{	dest [count] = lrintf (src [count] * normfact) + 128 ;
+	{	dest [count] = psf_lrintf (src [count] * normfact) + 128 ;
 		} ;
 } /* f2uc_array */
 
@@ -1846,7 +1846,7 @@ f2uc_clip_array	(const float *src, unsigned char *dest, int count, int normalize
 			continue ;
 			} ;
 
-		dest [count] = (lrintf (scaled_value) >> 24) + 128 ;
+		dest [count] = (psf_lrintf (scaled_value) >> 24) + 128 ;
 		} ;
 } /* f2uc_clip_array */
 
@@ -1888,7 +1888,7 @@ f2bes_array (const float *src, short *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 2 ;
-		value = lrintf (src [count] * normfact) ;
+		value = psf_lrintf (src [count] * normfact) ;
 		ucptr [1] = value ;
 		ucptr [0] = value >> 8 ;
 			} ;
@@ -1917,7 +1917,7 @@ f2bes_clip_array (const float *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrintf (scaled_value) ;
+		value = psf_lrintf (scaled_value) ;
 		ucptr [1] = value >> 16 ;
 		ucptr [0] = value >> 24 ;
 		} ;
@@ -1961,7 +1961,7 @@ f2les_array (const float *src, short *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 2 ;
-		value = lrintf (src [count] * normfact) ;
+		value = psf_lrintf (src [count] * normfact) ;
 		ucptr [0] = value ;
 		ucptr [1] = value >> 8 ;
 		} ;
@@ -1990,7 +1990,7 @@ f2les_clip_array (const float *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrintf (scaled_value) ;
+		value = psf_lrintf (scaled_value) ;
 		ucptr [0] = value >> 16 ;
 		ucptr [1] = value >> 24 ;
 		} ;
@@ -2031,7 +2031,7 @@ f2let_array (const float *src, tribyte *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7FFFFF) : 1.0 ;
 
 	while (--count >= 0)
-	{	value = lrintf (src [count] * normfact) ;
+	{	value = psf_lrintf (src [count] * normfact) ;
 		dest [count].bytes [0] = value ;
 		dest [count].bytes [1] = value >> 8 ;
 		dest [count].bytes [2] = value >> 16 ;
@@ -2060,7 +2060,7 @@ f2let_clip_array (const float *src, tribyte *dest, int count, int normalize)
 			continue ;
 		} ;
 
-		value = lrintf (scaled_value) ;
+		value = psf_lrintf (scaled_value) ;
 		dest [count].bytes [0] = value >> 8 ;
 		dest [count].bytes [1] = value >> 16 ;
 		dest [count].bytes [2] = value >> 24 ;
@@ -2102,7 +2102,7 @@ f2bet_array (const float *src, tribyte *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7FFFFF) : 1.0 ;
 
 	while (--count >= 0)
-	{	value = lrintf (src [count] * normfact) ;
+	{	value = psf_lrintf (src [count] * normfact) ;
 		dest [count].bytes [0] = value >> 16 ;
 		dest [count].bytes [1] = value >> 8 ;
 		dest [count].bytes [2] = value ;
@@ -2131,7 +2131,7 @@ f2bet_clip_array (const float *src, tribyte *dest, int count, int normalize)
 			continue ;
 		} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		dest [count].bytes [0] = value >> 24 ;
 		dest [count].bytes [1] = value >> 16 ;
 		dest [count].bytes [2] = value >> 8 ;
@@ -2175,7 +2175,7 @@ f2bei_array (const float *src, int *dest, int count, int normalize)
 	ucptr = ((unsigned char*) dest) + 4 * count ;
 	while (--count >= 0)
 	{	ucptr -= 4 ;
-		value = lrintf (src [count] * normfact) ;
+		value = psf_lrintf (src [count] * normfact) ;
 		ucptr [0] = value >> 24 ;
 		ucptr [1] = value >> 16 ;
 		ucptr [2] = value >> 8 ;
@@ -2210,7 +2210,7 @@ f2bei_clip_array (const float *src, int *dest, int count, int normalize)
 			continue ;
 		} ;
 
-		value = lrintf (scaled_value) ;
+		value = psf_lrintf (scaled_value) ;
 		ucptr [0] = value >> 24 ;
 		ucptr [1] = value >> 16 ;
 		ucptr [2] = value >> 8 ;
@@ -2256,7 +2256,7 @@ f2lei_array (const float *src, int *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 4 ;
-		value = lrintf (src [count] * normfact) ;
+		value = psf_lrintf (src [count] * normfact) ;
 		ucptr [0] = value ;
 		ucptr [1] = value >> 8 ;
 		ucptr [2] = value >> 16 ;
@@ -2291,7 +2291,7 @@ f2lei_clip_array (const float *src, int *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrintf (scaled_value) ;
+		value = psf_lrintf (scaled_value) ;
 		ucptr [0] = value ;
 		ucptr [1] = value >> 8 ;
 		ucptr [2] = value >> 16 ;
@@ -2333,7 +2333,7 @@ d2sc_array	(const double *src, signed char *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7F) : 1.0 ;
 
 	while (--count >= 0)
-	{	dest [count] = lrint (src [count] * normfact) ;
+	{	dest [count] = psf_lrint (src [count] * normfact) ;
 		} ;
 } /* d2sc_array */
 
@@ -2354,7 +2354,7 @@ d2sc_clip_array	(const double *src, signed char *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		dest [count] = lrintf (scaled_value) >> 24 ;
+		dest [count] = psf_lrintf (scaled_value) >> 24 ;
 		} ;
 } /* d2sc_clip_array */
 
@@ -2392,7 +2392,7 @@ d2uc_array	(const double *src, unsigned char *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7F) : 1.0 ;
 
 	while (--count >= 0)
-	{	dest [count] = lrint (src [count] * normfact) + 128 ;
+	{	dest [count] = psf_lrint (src [count] * normfact) + 128 ;
 		} ;
 } /* d2uc_array */
 
@@ -2413,7 +2413,7 @@ d2uc_clip_array	(const double *src, unsigned char *dest, int count, int normaliz
 			continue ;
 			} ;
 
-		dest [count] = (lrint (src [count] * normfact) >> 24) + 128 ;
+		dest [count] = (psf_lrint (src [count] * normfact) >> 24) + 128 ;
 		} ;
 } /* d2uc_clip_array */
 
@@ -2455,7 +2455,7 @@ d2bes_array (const double *src, short *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 2 ;
-		value = lrint (src [count] * normfact) ;
+		value = psf_lrint (src [count] * normfact) ;
 		ucptr [1] = value ;
 		ucptr [0] = value >> 8 ;
 		} ;
@@ -2484,7 +2484,7 @@ d2bes_clip_array (const double *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		ucptr [1] = value >> 16 ;
 		ucptr [0] = value >> 24 ;
 		} ;
@@ -2528,7 +2528,7 @@ d2les_array (const double *src, short *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 2 ;
-		value = lrint (src [count] * normfact) ;
+		value = psf_lrint (src [count] * normfact) ;
 		ucptr [0] = value ;
 		ucptr [1] = value >> 8 ;
 		} ;
@@ -2557,7 +2557,7 @@ d2les_clip_array (const double *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		ucptr [0] = value >> 16 ;
 		ucptr [1] = value >> 24 ;
 		} ;
@@ -2598,7 +2598,7 @@ d2let_array (const double *src, tribyte *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7FFFFF) : 1.0 ;
 
 	while (--count >= 0)
-	{	value = lrint (src [count] * normfact) ;
+	{	value = psf_lrint (src [count] * normfact) ;
 		dest [count].bytes [0] = value ;
 		dest [count].bytes [1] = value >> 8 ;
 		dest [count].bytes [2] = value >> 16 ;
@@ -2627,7 +2627,7 @@ d2let_clip_array (const double *src, tribyte *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		dest [count].bytes [0] = value >> 8 ;
 		dest [count].bytes [1] = value >> 16 ;
 		dest [count].bytes [2] = value >> 24 ;
@@ -2669,7 +2669,7 @@ d2bet_array (const double *src, tribyte *dest, int count, int normalize)
 	normfact = normalize ? (1.0 * 0x7FFFFF) : 1.0 ;
 
 	while (--count >= 0)
-	{	value = lrint (src [count] * normfact) ;
+	{	value = psf_lrint (src [count] * normfact) ;
 		dest [count].bytes [2] = value ;
 		dest [count].bytes [1] = value >> 8 ;
 		dest [count].bytes [0] = value >> 16 ;
@@ -2698,7 +2698,7 @@ d2bet_clip_array (const double *src, tribyte *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		dest [count].bytes [2] = value >> 8 ;
 		dest [count].bytes [1] = value >> 16 ;
 		dest [count].bytes [0] = value >> 24 ;
@@ -2743,7 +2743,7 @@ d2bei_array (const double *src, int *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 4 ;
-		value = lrint (src [count] * normfact) ;
+		value = psf_lrint (src [count] * normfact) ;
 		ucptr [0] = value >> 24 ;
 		ucptr [1] = value >> 16 ;
 		ucptr [2] = value >> 8 ;
@@ -2778,7 +2778,7 @@ d2bei_clip_array (const double *src, int *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		ucptr [0] = value >> 24 ;
 		ucptr [1] = value >> 16 ;
 		ucptr [2] = value >> 8 ;
@@ -2824,7 +2824,7 @@ d2lei_array (const double *src, int *dest, int count, int normalize)
 
 	while (--count >= 0)
 	{	ucptr -= 4 ;
-		value = lrint (src [count] * normfact) ;
+		value = psf_lrint (src [count] * normfact) ;
 		ucptr [0] = value ;
 		ucptr [1] = value >> 8 ;
 		ucptr [2] = value >> 16 ;
@@ -2859,7 +2859,7 @@ d2lei_clip_array (const double *src, int *dest, int count, int normalize)
 			continue ;
 			} ;
 
-		value = lrint (scaled_value) ;
+		value = psf_lrint (scaled_value) ;
 		ucptr [0] = value ;
 		ucptr [1] = value >> 8 ;
 		ucptr [2] = value >> 16 ;

--- a/src/sfconfig.h
+++ b/src/sfconfig.h
@@ -124,6 +124,10 @@
 #define CPU_IS_X86_64	0
 #endif
 
+#if CPU_IS_X86 && HAVE_IMMINTRIN_H
+#define USE_SSE2
+#endif
+
 #ifndef HAVE_SSIZE_T
 #define HAVE_SSIZE_T 0
 #endif

--- a/src/ulaw.c
+++ b/src/ulaw.c
@@ -841,9 +841,9 @@ static inline void
 f2ulaw_array (const float *ptr, int count, unsigned char *buffer, float normfact)
 {	while (--count >= 0)
 	{	if (ptr [count] >= 0)
-			buffer [count] = ulaw_encode [lrintf (normfact * ptr [count])] ;
+			buffer [count] = ulaw_encode [psf_lrintf (normfact * ptr [count])] ;
 		else
-			buffer [count] = 0x7F & ulaw_encode [- lrintf (normfact * ptr [count])] ;
+			buffer [count] = 0x7F & ulaw_encode [- psf_lrintf (normfact * ptr [count])] ;
 		} ;
 } /* f2ulaw_array */
 
@@ -853,9 +853,9 @@ d2ulaw_array (const double *ptr, int count, unsigned char *buffer, double normfa
 	{	if (!isfinite (ptr [count]))
 			buffer [count] = 0 ;
 		else if (ptr [count] >= 0)
-			buffer [count] = ulaw_encode [lrint (normfact * ptr [count])] ;
+			buffer [count] = ulaw_encode [psf_lrint (normfact * ptr [count])] ;
 		else
-			buffer [count] = 0x7F & ulaw_encode [- lrint (normfact * ptr [count])] ;
+			buffer [count] = 0x7F & ulaw_encode [- psf_lrint (normfact * ptr [count])] ;
 		} ;
 } /* d2ulaw_array */
 

--- a/src/vox_adpcm.c
+++ b/src/vox_adpcm.c
@@ -356,7 +356,7 @@ vox_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : (int) len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrintf (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrintf (normfact * ptr [total + k]) ;
 		count = vox_write_block (psf, pvox, sptr, writecount) ;
 		total += count ;
 		len -= writecount ;
@@ -387,7 +387,7 @@ vox_write_d	(SF_PRIVATE *psf, const double *ptr, sf_count_t len)
 	while (len > 0)
 	{	writecount = (len >= bufferlen) ? bufferlen : (int) len ;
 		for (k = 0 ; k < writecount ; k++)
-			sptr [k] = lrint (normfact * ptr [total + k]) ;
+			sptr [k] = psf_lrint (normfact * ptr [total + k]) ;
 		count = vox_write_block (psf, pvox, sptr, writecount) ;
 		total += count ;
 		len -= writecount ;

--- a/src/xi.c
+++ b/src/xi.c
@@ -1072,7 +1072,7 @@ f2dsc_array (XI_PRIVATE *pxi, const float *src, signed char *dest, int count, fl
 	last_val = pxi->last_16 >> 8 ;
 
 	for (k = 0 ; k < count ; k++)
-	{	current = lrintf (src [k] * normfact) ;
+	{	current = psf_lrintf (src [k] * normfact) ;
 		dest [k] = current - last_val ;
 		last_val = current ;
 		} ;
@@ -1088,7 +1088,7 @@ d2dsc_array (XI_PRIVATE *pxi, const double *src, signed char *dest, int count, d
 	last_val = pxi->last_16 >> 8 ;
 
 	for (k = 0 ; k < count ; k++)
-	{	current = lrint (src [k] * normfact) ;
+	{	current = psf_lrint (src [k] * normfact) ;
 		dest [k] = current - last_val ;
 		last_val = current ;
 		} ;
@@ -1202,7 +1202,7 @@ f2dles_array (XI_PRIVATE *pxi, const float *src, short *dest, int count, float n
 	last_val = pxi->last_16 ;
 
 	for (k = 0 ; k < count ; k++)
-	{	current = lrintf (src [k] * normfact) ;
+	{	current = psf_lrintf (src [k] * normfact) ;
 		diff = current - last_val ;
 		dest [k] = LE2H_16 (diff) ;
 		last_val = current ;
@@ -1219,7 +1219,7 @@ d2dles_array (XI_PRIVATE *pxi, const double *src, short *dest, int count, double
 	last_val = pxi->last_16 ;
 
 	for (k = 0 ; k < count ; k++)
-	{	current = lrint (src [k] * normfact) ;
+	{	current = psf_lrint (src [k] * normfact) ;
 		diff = current - last_val ;
 		dest [k] = LE2H_16 (diff) ;
 		last_val = current ;


### PR DESCRIPTION
`lrint`() and `lrintf`() are ridiculously slow when libsndfile is built using Visual C++.

On x86 and AMD64 platforms this patch adds SSE2 optimized versions.

It is safe to assume that non-SSE2 processors are no longer available to avoid unnecessary checks.