### PR TITLE
Fix CMake bug with sndio library dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,7 +471,7 @@ if (BUILD_PROGRAMS)
 	elseif ((NOT BEOS) AND ALSA_FOUND)
 		target_include_directories (sndfile-play PRIVATE ${ALSA_INCLUDE_DIRS})
 		target_link_libraries (sndfile-play PRIVATE ${ALSA_LIBRARIES})
-	elseif ((NOT BEOS) AND SNDIO_FOUND)
+	elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 		target_link_libraries (sndfile-play PRIVATE Sndio::Sndio)
 	endif ()
 

--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -22,9 +22,10 @@ else ()
 endif ()
 set (SF_COUNT_MAX 0x7fffffffffffffffll)
 
-if (NOT WIN32)
-	find_package (ALSA)
+if (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 	find_package (Sndio)
+elseif (NOT WIN32)
+	find_package (ALSA)
 endif ()
 
 if (VCPKG_TOOLCHAIN AND (NOT CMAKE_VERSION VERSION_LESS 3.15))


### PR DESCRIPTION
In configure.ac sndio search is restricted to OpenBSD OS, make the same
for CMake.