### PR TITLE
docs: fix simple typo, suppiled -> supplied

### DIFF
--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -583,7 +583,7 @@ sf_format_check	(const SF_INFO *info)
 	subformat = SF_CODEC (info->format) ;
 	endian = SF_ENDIAN (info->format) ;
 
-	/* This is the place where each file format can check if the suppiled
+	/* This is the place where each file format can check if the supplied
 	** SF_INFO struct is valid.
 	** Return 0 on failure, 1 ons success.
 	*/


### PR DESCRIPTION
There is a small typo in src/sndfile.c.

Should read `supplied` rather than `suppiled`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md