### PR TITLE
Add .ogg to major_formats

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -71,7 +71,7 @@ static SF_FORMAT_INFO const simple_formats [] =
 		},
 
 	{	SF_FORMAT_OGG | SF_FORMAT_VORBIS,
-		"Ogg Vorbis (Xiph Foundation)", "oga"
+		"Ogg Vorbis (Xiph Foundation)", "ogg"
 		},
 #endif
 


### PR DESCRIPTION
I wrote this bit of code for getting all the available extensions supported by libsndfile:

```cpp
QList<QString> extensions;

int count;
sf_command(nullptr, SFC_GET_FORMAT_MAJOR_COUNT, &count, sizeof(int));

for (int i = 0; i < count; i++) {
	SF_FORMAT_INFO info;
	info.format = i;
	sf_command(nullptr, SFC_GET_FORMAT_MAJOR, &info, sizeof(info));
	extensions.push_back(QString(info.extension).toLower());
};

return extensions;
```

Eventually I find out that my `ogg` files are ignored because the extension isn't included in `major_formats`

Perhaps we can also add `ogv` if that's supported. All extensions `oga`, `ogg` and `ogv` hold vorbis audio data.