### PR TITLE
ID3v2 skip fixes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -877,6 +877,7 @@ header_seek (SF_PRIVATE *psf, sf_count_t position, int whence)
 				psf_bump_header_allocation (psf, position) ;
 			if (position > psf->header.len)
 			{	/* Too much header to cache so just seek instead. */
+				psf->header.indx = psf->header.end ;
 				psf_fseek (psf, position, whence) ;
 				return ;
 				} ;

--- a/src/id3.c
+++ b/src/id3.c
@@ -47,10 +47,10 @@ id3_skip (SF_PRIVATE * psf)
 			return 0 ;
 
 		/* Calculate new file offset and position ourselves there. */
-		psf->fileoffset += offset + 10 ;
-
-		if (psf->fileoffset < psf->filelength)
-		{	psf_binheader_readf (psf, "p", psf->fileoffset) ;
+		offset += 10 ;
+		if (psf->fileoffset + offset < psf->filelength)
+		{	psf_binheader_readf (psf, "p", offset) ;
+			psf->fileoffset += offset ;
 			return 1 ;
 			} ;
 		} ;

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -2776,7 +2776,8 @@ guess_file_type (SF_PRIVATE *psf)
 	if (buffer [0] == MAKE_MARKER ('R', 'F', '6', '4') && buffer [2] == MAKE_MARKER ('W', 'A', 'V', 'E'))
 		return SF_FORMAT_RF64 ;
 
-	if (buffer [0] == MAKE_MARKER ('I', 'D', '3', 3))
+	if (buffer [0] == MAKE_MARKER ('I', 'D', '3', 2) || buffer [0] == MAKE_MARKER ('I', 'D', '3', 3)
+			|| buffer [0] == MAKE_MARKER ('I', 'D', '3', 4))
 	{	psf_log_printf (psf, "Found 'ID3' marker.\n") ;
 		if (id3_skip (psf))
 			return guess_file_type (psf) ;


### PR DESCRIPTION
Fix a bug in id3.c where large ID3v2 headers would fail to seek to the embedded file. ID3v2 tags are skipped over, treating the wrapped file as an embedded file. `id3_skip()` sets the embedded file offset to be just after the ID3v2 tag ends, then seeks the `psf_binheader()` to the fileoffset.

`psf_binheader_read()` accomplishes seeks by either reading and buffering bytes until the offset is reached, or if the buffer would be too large, seeking the underlying file instead using `psf_fseek()`. `psf_fread()` does not take the embedded file offset into account, while `psf_fseek()` does.

In the case of ID3 tags larger than the binheader buffer max, this has the effect of seeking to twice the id3v2 tag length, as
`psf_fseek(fileoffset, SEEK_CUR)` adds the fileoffset to the offset argument again. This lands in the middle of a stream which then cannot be identified.

To resolve the issue, seek the binheader *before* setting the embedded file offset.

Also, identify ID3v2.2 and ID3v2.4 headers. Previously only ID3v2.3 headers were identified.

An as-yet unresolved issue is that `id3_skip()` of large ID3v2 tags does not work on pipes as pipes do not support seeking.