### PR TITLE
Fix use of uninitialized value in endswap_int64_t_array

### DIFF
--- a/src/double64.c
+++ b/src/double64.c
@@ -631,7 +631,7 @@ host_read_d2f	(SF_PRIVATE *psf, float *ptr, sf_count_t len)
 		readcount = psf_fread (ubuf.dbuf, sizeof (double), bufferlen, psf) ;
 
 		if (psf->data_endswap == SF_TRUE)
-			endswap_double_array (ubuf.dbuf, bufferlen) ;
+			endswap_double_array (ubuf.dbuf, readcount) ;
 
 		d2f_array (ubuf.dbuf, readcount, ptr + total) ;
 		total += readcount ;


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25366

Credit to OSS-Fuzz.