### PR TITLE
Fix memory leak in caf_read_header()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Typo in `docs/index.md`.
+* Memory leak in `caf_read_header`(), credit to OSS-Fuzz ([issue 30375](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30375)).
 
 [Unreleased]: https://github.com/libsndfile/libsndfile/compare/1.0.31...HEAD

--- a/src/caf.c
+++ b/src/caf.c
@@ -416,6 +416,11 @@ caf_read_header (SF_PRIVATE *psf)
 					return SFE_CAF_BAD_PEAK ;
 					} ;
 
+				if (psf->peak_info)
+				{	psf_log_printf (psf, "*** Found existing peak info, using last one.\n") ;
+					free (psf->peak_info) ;
+					psf->peak_info = NULL ;
+					} ;
 				if ((psf->peak_info = peak_info_calloc (psf->sf.channels)) == NULL)
 					return SFE_MALLOC_FAILED ;
 


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30375

Credit to OSS-Fuzz.