### PR TITLE
Fix pedantic warnings

### DIFF
--- a/regtest/database.c
+++ b/regtest/database.c
@@ -267,14 +267,14 @@ db_check_all (REG_DB * db_handle)
 int
 db_list_all (REG_DB * db_handle)
 {
-	printf ("%s : %p\n", __func__, db_handle) ;
+	printf ("%s : %p\n", __func__, (void *) db_handle) ;
 	return 0 ;
 } /* db_list_all */
 
 int
 db_del_entry (REG_DB * db_handle, const char * entry)
 {
-	printf ("%s : %p %s\n", __func__, db_handle, entry) ;
+	printf ("%s : %p %s\n", __func__, (void *) db_handle, entry) ;
 	return 0 ;
 } /* db_del_entry */
 

--- a/src/ALAC/alac_codec.h
+++ b/src/ALAC/alac_codec.h
@@ -48,7 +48,7 @@ typedef struct alac_decoder_s
 	{
 		int32_t			mPredictor [ALAC_FRAME_LENGTH] ;
 		uint16_t		mShiftBuffer [ALAC_FRAME_LENGTH] ;
-	} ;
+	} u ;
 	uint32_t			mNumChannels ;
 } ALAC_DECODER ;
 

--- a/src/ALAC/alac_decoder.c
+++ b/src/ALAC/alac_decoder.c
@@ -110,7 +110,7 @@ alac_decoder_init (ALAC_DECODER *p, void * inMagicCookie, uint32_t inMagicCookie
 
 		RequireAction (p->mConfig.compatibleVersion <= kALACVersion, return kALAC_IncompatibleVersion ;) ;
 		RequireAction ((p->mConfig.bitDepth >= 8 && p->mConfig.bitDepth <= 32), return kALAC_BadBitWidth ;) ;
-		RequireAction ((p->mMixBufferU != NULL) && (p->mMixBufferV != NULL) && (p->mPredictor != NULL),
+		RequireAction ((p->mMixBufferU != NULL) && (p->mMixBufferV != NULL) && (p->u.mPredictor != NULL),
 						status = kALAC_MemFullError ; goto Exit ;) ;
 	}
 	else
@@ -247,18 +247,18 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 
 					// decompress
 					set_ag_params (&agParams, p->mConfig.mb, (pb * pbFactorU) / 4, p->mConfig.kb, numSamples, numSamples, p->mConfig.maxRun) ;
-					status = dyn_decomp (&agParams, bits, p->mPredictor, numSamples, chanBits, &bits1) ;
+					status = dyn_decomp (&agParams, bits, p->u.mPredictor, numSamples, chanBits, &bits1) ;
 					RequireNoErr (status, goto Exit ;) ;
 
 					if (modeU == 0)
 					{
-						unpc_block (p->mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
+						unpc_block (p->u.mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
 					}
 					else
 					{
 						// the special "numActive == 31" mode can be done in-place
-						unpc_block (p->mPredictor, p->mPredictor, numSamples, NULL, 31, chanBits, 0) ;
-						unpc_block (p->mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
+						unpc_block (p->u.mPredictor, p->u.mPredictor, numSamples, NULL, 31, chanBits, 0) ;
+						unpc_block (p->u.mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
 					}
 				}
 				else
@@ -300,7 +300,7 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 					//Assert (shift <= 16) ;
 
 					for (i = 0 ; i < numSamples ; i++)
-						p->mShiftBuffer [i] = (uint16_t) BitBufferRead (&shiftBits, (uint8_t) shift) ;
+						p->u.mShiftBuffer [i] = (uint16_t) BitBufferRead (&shiftBits, (uint8_t) shift) ;
 				}
 
 				// convert 32-bit integers into output buffer
@@ -318,14 +318,14 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 					case 24:
 						out32 = sampleBuffer + channelIndex ;
 						if (bytesShifted != 0)
-							copyPredictorTo24Shift (p->mMixBufferU, p->mShiftBuffer, out32, numChannels, numSamples, bytesShifted) ;
+							copyPredictorTo24Shift (p->mMixBufferU, p->u.mShiftBuffer, out32, numChannels, numSamples, bytesShifted) ;
 						else
 							copyPredictorTo24 (p->mMixBufferU, out32, numChannels, numSamples) ;
 						break ;
 					case 32:
 						out32 = sampleBuffer + channelIndex ;
 						if (bytesShifted != 0)
-							copyPredictorTo32Shift (p->mMixBufferU, p->mShiftBuffer, out32, numChannels, numSamples, bytesShifted) ;
+							copyPredictorTo32Shift (p->mMixBufferU, p->u.mShiftBuffer, out32, numChannels, numSamples, bytesShifted) ;
 						else
 							copyPredictorTo32 (p->mMixBufferU, out32, numChannels, numSamples) ;
 						break ;
@@ -408,34 +408,34 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 
 					// decompress and run predictor for "left" channel
 					set_ag_params (&agParams, p->mConfig.mb, (pb * pbFactorU) / 4, p->mConfig.kb, numSamples, numSamples, p->mConfig.maxRun) ;
-					status = dyn_decomp (&agParams, bits, p->mPredictor, numSamples, chanBits, &bits1) ;
+					status = dyn_decomp (&agParams, bits, p->u.mPredictor, numSamples, chanBits, &bits1) ;
 					RequireNoErr (status, goto Exit ;) ;
 
 					if (modeU == 0)
 					{
-						unpc_block (p->mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
+						unpc_block (p->u.mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
 					}
 					else
 					{
 						// the special "numActive == 31" mode can be done in-place
-						unpc_block (p->mPredictor, p->mPredictor, numSamples, NULL, 31, chanBits, 0) ;
-						unpc_block (p->mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
+						unpc_block (p->u.mPredictor, p->u.mPredictor, numSamples, NULL, 31, chanBits, 0) ;
+						unpc_block (p->u.mPredictor, p->mMixBufferU, numSamples, &coefsU [0], numU, chanBits, denShiftU) ;
 					}
 
 					// decompress and run predictor for "right" channel
 					set_ag_params (&agParams, p->mConfig.mb, (pb * pbFactorV) / 4, p->mConfig.kb, numSamples, numSamples, p->mConfig.maxRun) ;
-					status = dyn_decomp (&agParams, bits, p->mPredictor, numSamples, chanBits, &bits2) ;
+					status = dyn_decomp (&agParams, bits, p->u.mPredictor, numSamples, chanBits, &bits2) ;
 					RequireNoErr (status, goto Exit ;) ;
 
 					if (modeV == 0)
 					{
-						unpc_block (p->mPredictor, p->mMixBufferV, numSamples, &coefsV [0], numV, chanBits, denShiftV) ;
+						unpc_block (p->u.mPredictor, p->mMixBufferV, numSamples, &coefsV [0], numV, chanBits, denShiftV) ;
 					}
 					else
 					{
 						// the special "numActive == 31" mode can be done in-place
-						unpc_block (p->mPredictor, p->mPredictor, numSamples, NULL, 31, chanBits, 0) ;
-						unpc_block (p->mPredictor, p->mMixBufferV, numSamples, &coefsV [0], numV, chanBits, denShiftV) ;
+						unpc_block (p->u.mPredictor, p->u.mPredictor, numSamples, NULL, 31, chanBits, 0) ;
+						unpc_block (p->u.mPredictor, p->mMixBufferV, numSamples, &coefsV [0], numV, chanBits, denShiftV) ;
 					}
 				}
 				else
@@ -488,8 +488,8 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 
 					for (i = 0 ; i < (numSamples * 2) ; i += 2)
 					{
-						p->mShiftBuffer [i + 0] = (uint16_t) BitBufferRead (&shiftBits, (uint8_t) shift) ;
-						p->mShiftBuffer [i + 1] = (uint16_t) BitBufferRead (&shiftBits, (uint8_t) shift) ;
+						p->u.mShiftBuffer [i + 0] = (uint16_t) BitBufferRead (&shiftBits, (uint8_t) shift) ;
+						p->u.mShiftBuffer [i + 1] = (uint16_t) BitBufferRead (&shiftBits, (uint8_t) shift) ;
 					}
 				}
 
@@ -508,12 +508,12 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 					case 24:
 						out32 = sampleBuffer + channelIndex ;
 						unmix24 (p->mMixBufferU, p->mMixBufferV, out32, numChannels, numSamples,
-									mixBits, mixRes, p->mShiftBuffer, bytesShifted) ;
+									mixBits, mixRes, p->u.mShiftBuffer, bytesShifted) ;
 						break ;
 					case 32:
 						out32 = sampleBuffer + channelIndex ;
 						unmix32 (p->mMixBufferU, p->mMixBufferV, out32, numChannels, numSamples,
-									mixBits, mixRes, p->mShiftBuffer, bytesShifted) ;
+									mixBits, mixRes, p->u.mShiftBuffer, bytesShifted) ;
 						break ;
 				}
 

--- a/src/common.c
+++ b/src/common.c
@@ -1246,7 +1246,7 @@ psf_memset (void *s, int c, sf_count_t len)
 ** bodgy something up instead.
 */
 
-typedef SF_CUES_VAR (0) SF_CUES_0 ;
+typedef SF_CUES_VAR () SF_CUES_0 ;
 
 /* calculate size of SF_CUES struct given number of cues */
 #define SF_CUES_VAR_SIZE(count)	(sizeof (SF_CUES_0) + count * sizeof (SF_CUE_POINT))

--- a/src/common.c
+++ b/src/common.c
@@ -1625,7 +1625,7 @@ psf_f2s_clip_array (const float *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 		if (CPU_CLIPS_NEGATIVE == 0 && scaled_value <= (-8.0 * 0x1000))
-		{	dest [count] = 0x8000 ;
+		{	dest [count] = -0x7FFF - 1 ;
 			continue ;
 			} ;
 
@@ -1659,7 +1659,7 @@ psf_d2s_clip_array (const double *src, short *dest, int count, int normalize)
 			continue ;
 			} ;
 		if (CPU_CLIPS_NEGATIVE == 0 && scaled_value <= (-8.0 * 0x1000))
-		{	dest [count] = 0x8000 ;
+		{	dest [count] = -0x7FFF - 1 ;
 			continue ;
 			} ;
 

--- a/src/common.h
+++ b/src/common.h
@@ -101,22 +101,8 @@
 
 #define		NOT(x)			(! (x))
 
-#if COMPILER_IS_GCC
-#define		SF_MAX(x, y)	({ \
-								typeof (x) sf_max_x1 = (x) ; \
-								typeof (y) sf_max_y1 = (y) ; \
-								(void) (&sf_max_x1 == &sf_max_y1) ; \
-								sf_max_x1 > sf_max_y1 ? sf_max_x1 : sf_max_y1 ; })
-
-#define		SF_MIN(x, y)	({ \
-								typeof (x) sf_min_x2 = (x) ; \
-								typeof (y) sf_min_y2 = (y) ; \
-								(void) (&sf_min_x2 == &sf_min_y2) ; \
-								sf_min_x2 < sf_min_y2 ? sf_min_x2 : sf_min_y2 ; })
-#else
 #define		SF_MAX(a, b)	((a) > (b) ? (a) : (b))
 #define		SF_MIN(a, b)	((a) < (b) ? (a) : (b))
-#endif
 
 
 #define		COMPILE_TIME_ASSERT(e)	(sizeof (struct { int : - !! (e) ; }))

--- a/src/test_broadcast_var.c
+++ b/src/test_broadcast_var.c
@@ -89,7 +89,7 @@ test_broadcast_var_set (void)
 static void
 test_broadcast_var_zero (void)
 {	SF_PRIVATE	sf_private, *psf ;
-	SF_BROADCAST_INFO_VAR (0) bi ;
+	SF_BROADCAST_INFO_VAR () bi ;
 
 	psf = &sf_private ;
 	memset (psf, 0, sizeof (sf_private)) ;

--- a/src/wav.c
+++ b/src/wav.c
@@ -77,13 +77,13 @@
 
 
 enum
-{	HAVE_RIFF	= 0x01,
-	HAVE_WAVE	= 0x02,
-	HAVE_fmt	= 0x04,
-	HAVE_fact	= 0x08,
-	HAVE_PEAK	= 0x10,
-	HAVE_data	= 0x20,
-	HAVE_other	= 0x80000000
+{	HAVE_RIFF	= 1 << 0,
+	HAVE_WAVE	= 1 << 1,
+	HAVE_fmt	= 1 << 2,
+	HAVE_fact	= 1 << 3,
+	HAVE_PEAK	= 1 << 4,
+	HAVE_data	= 1 << 5,
+	HAVE_other	= 1 << 6
 } ;
 
 

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -255,7 +255,7 @@ unrecognised_test (void)
 	sndfile = sf_open (filename, SFM_READ, &sfinfo) ;
 
 	exit_if_true (sndfile != NULL,
-		"\n\nLine %d : SNDFILE* pointer (%p) should ne NULL.\n", __LINE__, sndfile
+		"\n\nLine %d : SNDFILE* pointer (%p) should be NULL.\n", __LINE__, (void *) sndfile
 		) ;
 
 	k = sf_error (sndfile) ;


### PR DESCRIPTION
Warnings were spotted when compiling with `-Wall -Wextra -pedantic` using clang and GCC. This PR fixes all of the clang warnings, and most of the GCC warnings. The remaining GCC warnings are all `-Wformat-truncation=` where the buffer being written to is intentionally missing the terminating `NUL` (for example, `SF_BROADCAST_INFO::origination_date` which holds `"YYYY/MM/DD"` in 10 `char`s), but I've left them since I'm using clang.