### PR TITLE
Change test file names to avoid conflicts when running tests

### DIFF
--- a/tests/alaw_test.c
+++ b/tests/alaw_test.c
@@ -49,7 +49,7 @@ main (void)
 
 	print_test_name ("alaw_test", "encoder") ;
 
-	filename = "test.raw" ;
+	filename = "alaw_test.raw" ;
 
 	sf_info_setup (&sfinfo, SF_FORMAT_RAW | SF_FORMAT_ALAW, 44100, 1) ;
 

--- a/tests/command_test.c
+++ b/tests/command_test.c
@@ -115,8 +115,8 @@ main (int argc, char *argv [])
 	{	/*	Preliminary float/double normalisation tests. More testing
 		**	is done in the program 'floating_point_test'.
 		*/
-		float_norm_test		("float.wav") ;
-		double_norm_test	("double.wav") ;
+		float_norm_test		("cmd_float.wav") ;
+		double_norm_test	("cmd_double.wav") ;
 		test_count ++ ;
 		} ;
 

--- a/tests/compression_size_test.c
+++ b/tests/compression_size_test.c
@@ -37,6 +37,8 @@
 #define	SAMPLE_RATE		16000
 #define	DATA_LENGTH		(SAMPLE_RATE)
 
+static const char CMP_TEST_PREFIX[] = "cmp" ;
+
 static float data_out [DATA_LENGTH] ;
 
 static inline float
@@ -52,6 +54,8 @@ vorbis_test (void)
 	SF_INFO sfinfo ;
 	float max_abs = 0.0 ;
 	unsigned k ;
+
+	get_unique_test_name (&filename, CMP_TEST_PREFIX) ;
 
 	print_test_name ("vorbis_test", filename) ;
 
@@ -122,6 +126,8 @@ compression_size_test (int format, const char * filename)
 	int q3_size, q6_size ;
 	double quality ;
 	int k ;
+
+	get_unique_test_name (&filename, CMP_TEST_PREFIX) ;
 
 	snprintf (q3_fname, sizeof (q3_fname), "q3_%s", filename) ;
 	snprintf (q6_fname, sizeof (q6_fname), "q6_%s", filename) ;

--- a/tests/floating_point_test.tpl
+++ b/tests/floating_point_test.tpl
@@ -38,6 +38,8 @@
 
 #define	SAMPLE_RATE			16000
 
+static const char FPT_TEST_PREFIX[] = "fpt" ;
+
 static void	float_scaled_test	(const char *filename, int allow_exit, int replace_float, int filetype, double target_snr) ;
 static void	double_scaled_test	(const char *filename, int allow_exit, int replace_float, int filetype, double target_snr) ;
 
@@ -206,6 +208,7 @@ float_scaled_test (const char *filename, int allow_exit, int replace_float, int 
 	double		snr ;
 	int			byterate ;
 
+	get_unique_test_name (&filename, FPT_TEST_PREFIX) ;
 	print_test_name ("float_scaled_test", filename) ;
 
 	gen_windowed_sine_float (float_data, DFT_DATA_LENGTH, 0.9999) ;
@@ -259,6 +262,7 @@ double_scaled_test (const char *filename, int allow_exit, int replace_float, int
 	double		snr ;
 	int			byterate ;
 
+	get_unique_test_name (&filename, FPT_TEST_PREFIX) ;
 	print_test_name ("double_scaled_test", filename) ;
 
 	gen_windowed_sine_double (double_data, DFT_DATA_LENGTH, 0.9999) ;
@@ -317,6 +321,7 @@ static void
 	int			max ;
 	unsigned	k ;
 
+	get_unique_test_name (&filename, FPT_TEST_PREFIX) ;
 	print_test_name ("[+ (get "float_name") +]_[+ (get "int_name") +]_[+ (get "end_name") +]_test", filename) ;
 
 	gen_windowed_sine_[+ (get "float_name") +] ([+ (get "float_name") +]_data, ARRAY_LEN ([+ (get "float_name") +]_data), 0.9999) ;

--- a/tests/header_test.tpl
+++ b/tests/header_test.tpl
@@ -106,7 +106,7 @@ main (int argc, char *argv [])
 		update_seek_int_test ("header_int.aiff", SF_FORMAT_AIFF) ;
 		update_seek_float_test ("header_float.aiff", SF_FORMAT_AIFF) ;
 		update_seek_double_test ("header_double.aiff", SF_FORMAT_AIFF) ;
-		header_shrink_test ("header_shrink.wav", SF_FORMAT_AIFF) ;
+		header_shrink_test ("header_shrink.aiff", SF_FORMAT_AIFF) ;
 		extra_header_test ("extra.aiff", SF_FORMAT_AIFF) ;
 		test_count++ ;
 		} ;

--- a/tests/headerless_test.c
+++ b/tests/headerless_test.c
@@ -44,11 +44,11 @@ main (void)
 {
 	old_test () ;
 
-	headerless_test ("raw.vox", SF_FORMAT_VOX_ADPCM, SF_FORMAT_RAW | SF_FORMAT_VOX_ADPCM) ;
-	headerless_test ("raw.gsm", SF_FORMAT_GSM610, SF_FORMAT_RAW | SF_FORMAT_GSM610) ;
+	headerless_test ("headerless.vox", SF_FORMAT_VOX_ADPCM, SF_FORMAT_RAW | SF_FORMAT_VOX_ADPCM) ;
+	headerless_test ("headerless.gsm", SF_FORMAT_GSM610, SF_FORMAT_RAW | SF_FORMAT_GSM610) ;
 
-	headerless_test ("raw.snd", SF_FORMAT_ULAW, SF_FORMAT_RAW | SF_FORMAT_ULAW) ;
-	headerless_test ("raw.au" , SF_FORMAT_ULAW, SF_FORMAT_RAW | SF_FORMAT_ULAW) ;
+	headerless_test ("headerless.snd", SF_FORMAT_ULAW, SF_FORMAT_RAW | SF_FORMAT_ULAW) ;
+	headerless_test ("headerless.au" , SF_FORMAT_ULAW, SF_FORMAT_RAW | SF_FORMAT_ULAW) ;
 
 	return 0 ;
 } /* main */

--- a/tests/lossy_comp_test.c
+++ b/tests/lossy_comp_test.c
@@ -44,6 +44,8 @@
 
 #define		LCT_MAX(x, y)	((x) > (y) ? (x) : (y))
 
+static const char LCT_TEST_PREFIX[] = "lct" ;
+
 static	void	lcomp_test_short	(const char *filename, int filetype, int chan, double margin) ;
 static	void	lcomp_test_int		(const char *filename, int filetype, int chan, double margin) ;
 static	void	lcomp_test_float	(const char *filename, int filetype, int chan, double margin) ;
@@ -651,6 +653,7 @@ lcomp_test_short (const char *filename, int filetype, int channels, double margi
 	sf_count_t		datalen ;
 	short			*orig, *data ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("lcomp_test_short", filename) ;
 
 	datalen = BUFFER_SIZE / channels ;
@@ -838,6 +841,7 @@ lcomp_test_int (const char *filename, int filetype, int channels, double margin)
 	double			scale, max_val ;
 	int				*orig, *data ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("lcomp_test_int", filename) ;
 
 	datalen = BUFFER_SIZE / channels ;
@@ -1035,6 +1039,7 @@ lcomp_test_float (const char *filename, int filetype, int channels, double margi
 	float			*orig, *data ;
 	double			half_max_abs ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("lcomp_test_float", filename) ;
 
 	datalen = BUFFER_SIZE / channels ;
@@ -1229,6 +1234,7 @@ lcomp_test_double (const char *filename, int filetype, int channels, double marg
 	double			*orig, *data ;
 	double			half_max_abs ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("lcomp_test_double", filename) ;
 
 	datalen = BUFFER_SIZE / channels ;
@@ -1424,6 +1430,8 @@ sdlcomp_test_short	(const char *filename, int filetype, int channels, double mar
 	short			*orig, *data, *smooth ;
 
 channels = 1 ;
+
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("sdlcomp_test_short", filename) ;
 
 	datalen = BUFFER_SIZE ;
@@ -1644,6 +1652,7 @@ sdlcomp_test_int	(const char *filename, int filetype, int channels, double margi
 
 channels = 1 ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("sdlcomp_test_int", filename) ;
 
 	datalen = BUFFER_SIZE ;
@@ -1867,6 +1876,7 @@ sdlcomp_test_float	(const char *filename, int filetype, int channels, double mar
 
 channels = 1 ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("sdlcomp_test_float", filename) ;
 
 	switch ((filetype & SF_FORMAT_SUBMASK))
@@ -2111,6 +2121,8 @@ sdlcomp_test_double	(const char *filename, int filetype, int channels, double ma
 	double			*orig, *data, *smooth, half_max_abs, scale ;
 
 channels = 1 ;
+
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("sdlcomp_test_double", filename) ;
 
 	switch ((filetype & SF_FORMAT_SUBMASK))
@@ -2352,6 +2364,7 @@ read_raw_test (const char *filename, int filetype, int channels)
 	short			*orig, *data ;
 	int				k ;
 
+	get_unique_test_name (&filename, LCT_TEST_PREFIX) ;
 	print_test_name ("read_raw_test", filename) ;
 
 	datalen = ARRAY_LEN (orig_buffer.s) / 2 ;

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -37,6 +37,8 @@
 #define	BUFFER_LEN			(1 << 10)
 #define LOG_BUFFER_SIZE		1024
 
+static const char STR_TEST_PREFIX[] = "str" ;
+
 static void	string_start_test (const char *filename, int typemajor) ;
 static void	string_start_end_test (const char *filename, int typemajor) ;
 static void	string_multi_set_test (const char *filename, int typemajor) ;
@@ -207,6 +209,7 @@ string_start_end_test (const char *filename, int typemajor)
 	SF_INFO		sfinfo ;
 	int			errors = 0 ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name ("string_start_end_test", filename) ;
 
 	memset (&sfinfo, 0, sizeof (sfinfo)) ;
@@ -356,6 +359,7 @@ string_start_test (const char *filename, int formattype)
 	int			errors = 0 ;
 	int			typemajor = SF_FORMAT_TYPEMASK & formattype ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name ("string_start_test", filename) ;
 
 	memset (&sfinfo, 0, sizeof (sfinfo)) ;
@@ -497,6 +501,7 @@ string_multi_set_test (const char *filename, int typemajor)
 	SF_INFO		sfinfo ;
 	int			count ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name (__func__, filename) ;
 
 	memset (&sfinfo, 0, sizeof (sfinfo)) ;
@@ -566,6 +571,7 @@ string_rdwr_test (const char *filename, int typemajor)
 	sf_count_t frames ;
 	const char * str ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name (__func__, filename) ;
 	create_short_sndfile (filename, typemajor | SF_FORMAT_PCM_16, 2) ;
 
@@ -618,6 +624,7 @@ string_short_rdwr_test (const char *filename, int typemajor)
 	sf_count_t frames = BUFFER_LEN ;
 	const char * str ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name (__func__, filename) ;
 
 	memset (&sfinfo, 0, sizeof (sfinfo)) ;
@@ -687,6 +694,7 @@ static void
 software_string_test (const char *filename)
 {	size_t k ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name (__func__, filename) ;
 
 	for (k = 0 ; k < 50 ; k++)
@@ -727,6 +735,7 @@ string_rdwr_grow_test (const char *filename, int typemajor)
 	sf_count_t frames ;
 	const char * str ;
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name (__func__, filename) ;
 
 	/* Create a file that contains some strings. Then open the file in RDWR mode and
@@ -785,6 +794,7 @@ string_header_update (const char *filename, int typemajor)
 	const char * str ;
 	const int GROW_BUFFER_AMOUNT = 4 ; /* this should be less than half the size of the string header */
 
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
 	print_test_name (__func__, filename) ;
 
 	/* Create a short file. */

--- a/tests/ulaw_test.c
+++ b/tests/ulaw_test.c
@@ -49,7 +49,7 @@ main (void)
 
 	print_test_name ("ulaw_test", "encoder") ;
 
-	filename = "test.raw" ;
+	filename = "ulaw_test.raw" ;
 
 	sf_info_setup (&sfinfo, SF_FORMAT_RAW | SF_FORMAT_ULAW, 44100, 1) ;
 

--- a/tests/utils.tpl
+++ b/tests/utils.tpl
@@ -104,6 +104,8 @@ void	count_open_files (void) ;
 void	increment_open_file_count (void) ;
 void	check_open_file_count_or_die (int lineno) ;
 
+void	get_unique_test_name (const char ** filename, const char * test) ;
+
 #ifdef SNDFILE_H
 
 static inline void
@@ -850,6 +852,15 @@ check_open_file_count_or_die (int lineno)
 		} ;
 #endif
 } /* check_open_file_count_or_die */
+
+void
+get_unique_test_name (const char ** filename, const char * test)
+{	static char	buffer [1024] ;
+
+	snprintf (buffer, sizeof (buffer), "%s_%s", test, *filename) ;
+
+	*filename = buffer ;
+} /* get_unique_test_name */
 
 void
 write_mono_file (const char * filename, int format, int srate, float * output, int len)

--- a/tests/write_read_test.tpl
+++ b/tests/write_read_test.tpl
@@ -42,6 +42,8 @@
 
 #define	SILLY_WRITE_COUNT	(234)
 
+static const char WRT_TEST_PREFIX[] = "wrt" ;
+
 [+ FOR data_type
 +]static void	pcm_test_[+ (get "type_name") +] (const char *str, int format, int long_file_ok) ;
 [+ ENDFOR data_type
@@ -446,6 +448,7 @@ pcm_test_[+ (get "type_name") +] (const char *filename, int format, int long_fil
 	/* Sd2 files cannot be opened from an existing file descriptor. */
 	allow_fd = ((format & SF_FORMAT_TYPEMASK) == SF_FORMAT_SD2) ? SF_FALSE : SF_TRUE ;
 
+	get_unique_test_name (&filename, WRT_TEST_PREFIX) ;
 	print_test_name ("pcm_test_[+ (get "type_name") +]", filename) ;
 
 	sfinfo.samplerate	= 44100 ;
@@ -1008,6 +1011,7 @@ empty_file_test (const char *filename, int format)
 	/* Sd2 files cannot be opened from an existing file descriptor. */
 	allow_fd = ((format & SF_FORMAT_TYPEMASK) == SF_FORMAT_SD2) ? SF_FALSE : SF_TRUE ;
 
+	get_unique_test_name (&filename, WRT_TEST_PREFIX) ;
 	print_test_name ("empty_file_test", filename) ;
 
 	unlink (filename) ;


### PR DESCRIPTION
`ctest -j <N>` can fail sporadically due to tests sharing the same temporary file names. This PR fixes the issue by changing the names of all those that conflict.

I'm not sure if `get_unique_test_name()` is the best approach, but it was simpler than changing every string.