### PR TITLE
Fuzzer fixes

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -28,8 +28,6 @@
 #define TWOBIT_MARKER	(MAKE_MARKER ('2', 'B', 'I', 'T'))
 #define	AVR_HDR_SIZE	128
 
-#define	SFE_AVR_X	666
-
 /*
 ** From: hyc@hanauma.Jpl.Nasa.Gov (Howard Chu)
 **
@@ -116,7 +114,7 @@ avr_read_header (SF_PRIVATE *psf)
 	psf_log_printf (psf, "%M\n", hdr.marker) ;
 
 	if (hdr.marker != TWOBIT_MARKER)
-		return SFE_AVR_X ;
+		return SFE_AVR_NOT_AVR ;
 
 	psf_log_printf (psf, "  Name        : %s\n", hdr.name) ;
 
@@ -145,7 +143,7 @@ avr_read_header (SF_PRIVATE *psf)
 
 		default :
 			psf_log_printf (psf, "Error : bad rez/sign combination.\n") ;
-			return SFE_AVR_X ;
+			return SFE_AVR_BAD_REZ_SIGN ;
 		} ;
 
 	psf_binheader_readf (psf, "E4444", &hdr.srate, &hdr.frames, &hdr.lbeg, &hdr.lend) ;

--- a/src/caf.c
+++ b/src/caf.c
@@ -66,10 +66,6 @@
 
 #define CAF_PEAK_CHUNK_SIZE(ch) 	((int) (sizeof (int) + ch * (sizeof (float) + 8)))
 
-#define SFE_CAF_NOT_CAF	666
-#define SFE_CAF_NO_DESC	667
-#define SFE_CAF_BAD_PEAK 668
-
 /*------------------------------------------------------------------------------
 ** Typedefs.
 */

--- a/src/common.h
+++ b/src/common.h
@@ -754,6 +754,15 @@ enum
 
 	SFE_OPUS_BAD_SAMPLERATE,
 
+	SFE_CAF_NOT_CAF,
+	SFE_CAF_NO_DESC,
+	SFE_CAF_BAD_PEAK,
+
+	SFE_AVR_NOT_AVR,
+	SFE_AVR_BAD_REZ_SIGN,
+
+	SFE_MPC_NO_MARKER,
+
 	SFE_MAX_ERROR			/* This must be last in list. */
 } ;
 

--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -182,7 +182,12 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 	if (psf->file.mode != SFM_READ)
 		return SFE_BAD_MODE_RW ;
 
-	pimasize = sizeof (IMA_ADPCM_PRIVATE) + blockalign * psf->sf.channels + 3 * psf->sf.channels * samplesperblock ;
+	/*
+	**	Allocate enough space for 1 more than a multiple of 8 samples
+	**	to avoid having to branch when pulling apart the nibbles.
+	*/
+	count = ((samplesperblock - 2) | 7) + 2 ;
+	pimasize = sizeof (IMA_ADPCM_PRIVATE) + psf->sf.channels * (blockalign + samplesperblock + sizeof(short) * count) ;
 
 	if (! (pima = calloc (1, pimasize)))
 		return SFE_MALLOC_FAILED ;

--- a/src/mpc2k.c
+++ b/src/mpc2k.c
@@ -46,8 +46,6 @@
 #define HEADER_LENGTH		42	/* Sum of above data fields. */
 #define HEADER_NAME_LEN		17	/* Length of name string. */
 
-#define	SFE_MPC_NO_MARKER	666
-
 /*------------------------------------------------------------------------------
 ** Private static functions.
 */

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -279,6 +279,15 @@ ErrorStruct SndfileErrors [] =
 
 	{	SFE_OPUS_BAD_SAMPLERATE	, "Error : Opus only supports sample rates of 8000, 12000, 16000, 24000 and 48000." },
 
+	{	SFE_CAF_NOT_CAF			, "Error : Not a CAF file." },
+	{	SFE_CAF_NO_DESC			, "Error : No 'desc' marker in CAF file." },
+	{	SFE_CAF_BAD_PEAK		, "Error : Bad 'PEAK' chunk in CAF file." },
+
+	{	SFE_AVR_NOT_AVR			, "Error : Not an AVR file." },
+	{	SFE_AVR_BAD_REZ_SIGN	, "Error : Bad rez/sign combination." },
+
+	{	SFE_MPC_NO_MARKER		, "Error : No marker in MPC2K file." },
+
 	{	SFE_MAX_ERROR			, "Maximum error number." },
 	{	SFE_MAX_ERROR + 1		, NULL }
 } ;

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -2680,6 +2680,7 @@ static int
 guess_file_type (SF_PRIVATE *psf)
 {	uint32_t buffer [3], format ;
 
+retry:
 	if (psf_binheader_readf (psf, "b", &buffer, SIGNED_SIZEOF (buffer)) != SIGNED_SIZEOF (buffer))
 	{	psf->error = SFE_BAD_FILE_READ ;
 		return 0 ;
@@ -2780,7 +2781,7 @@ guess_file_type (SF_PRIVATE *psf)
 			|| buffer [0] == MAKE_MARKER ('I', 'D', '3', 4))
 	{	psf_log_printf (psf, "Found 'ID3' marker.\n") ;
 		if (id3_skip (psf))
-			return guess_file_type (psf) ;
+			goto retry ;
 		return 0 ;
 		} ;
 

--- a/src/svx.c
+++ b/src/svx.c
@@ -307,7 +307,8 @@ svx_read_header	(SF_PRIVATE *psf)
 					if ((chunk_size = psf_ftell (psf)) & 0x03)
 					{	psf_log_printf (psf, "  Unknown chunk marker at position %d. Resynching.\n", chunk_size - 4) ;
 
-						psf_binheader_readf (psf, "j", -3) ;
+						chunk_size = chunk_size & 3 ;
+						psf_binheader_readf (psf, "j", 4 - chunk_size) ;
 						break ;
 						} ;
 					psf_log_printf (psf, "*** Unknown chunk marker (%X) at position %D. Exiting parser.\n", marker, psf_ftell (psf) - 8) ;


### PR DESCRIPTION
This is the first batch of fixes for issues found by fuzzing `libsndfile` locally. UBSan has picked up another 140 issues (number still rising as fuzzing continues) but those are presumably of lower priority than the security issues I've since spotted on https://bugs.chromium.org/p/oss-fuzz/issues/list?q=libsndfile (which were all reported last year). The next batch of fixes will be in a separate PR once I find time to look into them.