### PR TITLE
Deprecate ENABLE_SNDFILE_WINDOWS_PROTOTYPES define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `SFC_SET_DITHER_ON_READ` and `SFC_SET_DITHER_ON_WRITE` enums comments in
   public header, thanks @SmiVan (issue #677).
+* `ENABLE_SNDFILE_WINDOWS_PROTOTYPES` define is deprecated and not needed
+  anymore.
+
+  Previously, in order for the [`sf_wchar_open`()](http://libsndfile.github.io/libsndfile/api.html#open)
+  function to become available on   the Windows platform, it was required to
+  perform certain actions:
+
+  ```c
+  #include <windows.h>
+  #define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+  #including <sndfile.h>
+  ```
+
+  These steps are no longer required and the `sf_wchar_open`() function is
+  always available on the Windows platform.
 
 ### Fixed
 

--- a/include/sndfile.h.in
+++ b/include/sndfile.h.in
@@ -755,16 +755,10 @@ void	sf_write_sync	(SNDFILE *sndfile) ;
 /* The function sf_wchar_open() is Windows Only!
 ** Open a file passing in a Windows Unicode filename. Otherwise, this is
 ** the same as sf_open().
-**
-** In order for this to work, you need to do the following:
-**
-**		#include <windows.h>
-**		#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-**		#including <sndfile.h>
 */
 
-#if (defined (ENABLE_SNDFILE_WINDOWS_PROTOTYPES) && ENABLE_SNDFILE_WINDOWS_PROTOTYPES)
-SNDFILE* sf_wchar_open (LPCWSTR wpath, int mode, SF_INFO *sfinfo) ;
+#ifdef _WIN32
+SNDFILE* sf_wchar_open (const wchar_t *wpath, int mode, SF_INFO *sfinfo) ;
 #endif
 
 

--- a/include/sndfile.hh
+++ b/include/sndfile.hh
@@ -88,8 +88,8 @@ class SndfileHandle
 			SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mode = SFM_READ,
 							int format = 0, int channels = 0, int samplerate = 0) ;
 
-#ifdef ENABLE_SNDFILE_WINDOWS_PROTOTYPES
-			SndfileHandle (LPCWSTR wpath, int mode = SFM_READ,
+#ifdef _WIN32
+			SndfileHandle (const wchar_t *wpath, int mode = SFM_READ,
 							int format = 0, int channels = 0, int samplerate = 0) ;
 #endif
 
@@ -422,10 +422,10 @@ SndfileHandle::takeOwnership (void)
 	return sf ;
 }
 
-#ifdef ENABLE_SNDFILE_WINDOWS_PROTOTYPES
+#ifdef _WIN32
 
 inline
-SndfileHandle::SndfileHandle (LPCWSTR wpath, int mode, int fmt, int chans, int srate)
+SndfileHandle::SndfileHandle (const wchar_t *wpath, int mode, int fmt, int chans, int srate)
 : p (nullptr)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;

--- a/src/windows.c
+++ b/src/windows.c
@@ -27,7 +27,6 @@
 #if OS_IS_WIN32
 #include <windows.h>
 
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #include "sndfile.h"
 #include "common.h"
 

--- a/tests/locale_test.c
+++ b/tests/locale_test.c
@@ -34,7 +34,6 @@
 
 #if OS_IS_WIN32
 #include <windows.h>
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #endif
 
 #include "sndfile.h"


### PR DESCRIPTION
Use standard `_WIN32` define instead. Any sane compiler on Windows platfrom defines `_WIN32`.

The `wpath` parameter type has been changed to an equivalent type that does not require the inclusion of the `windows.h` header.