### PR TITLE
oss-fuzz ASAN fixes

### DIFF
--- a/src/ms_adpcm.c
+++ b/src/ms_adpcm.c
@@ -128,8 +128,14 @@ wavlike_msadpcm_init	(SF_PRIVATE *psf, int blockalign, int samplesperblock)
 	if (psf->file.mode == SFM_WRITE)
 		samplesperblock = 2 + 2 * (blockalign - 7 * psf->sf.channels) / psf->sf.channels ;
 
-	if (blockalign < 7 * psf->sf.channels)
-	{	psf_log_printf (psf, "*** Error blockalign (%d) should be > %d.\n", blockalign, 7 * psf->sf.channels) ;
+	/* There's 7 samples per channel in the preamble of each block */
+	if (samplesperblock < 7 * psf->sf.channels)
+	{	psf_log_printf (psf, "*** Error samplesperblock (%d) should be >= %d.\n", samplesperblock, 7 * psf->sf.channels) ;
+		return SFE_INTERNAL ;
+		} ;
+
+	if (2 * blockalign < samplesperblock * psf->sf.channels)
+	{	psf_log_printf (psf, "*** Error blockalign (%d) should be >= %d.\n", blockalign, samplesperblock * psf->sf.channels / 2) ;
 		return SFE_INTERNAL ;
 		} ;
 

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -830,7 +830,11 @@ wavlike_read_cart_chunk (SF_PRIVATE *psf, uint32_t chunksize)
 		return 0 ;
 		} ;
 
-	if (chunksize >= sizeof (SF_CART_INFO_16K))
+	/*
+	**	SF_CART_INFO_16K has an extra field 'tag_text_size' that isn't part
+	**	of the chunk, so don't include it in the size check.
+	*/
+	if (chunksize >= sizeof (SF_CART_INFO_16K) - 4)
 	{	psf_log_printf (psf, "cart : %u too big to be handled\n", chunksize) ;
 		psf_binheader_readf (psf, "j", chunksize) ;
 		return 0 ;


### PR DESCRIPTION
This PR fixes the security issues spotted by oss-fuzz in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26026 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26803. Of the other publicly visible security issues only https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27503 looks frightening, and that looks like it'll go away once the UBSan issues in ALAC are fixed.