### PR TITLE
Revert "Fix zero-as-null-pointer-constant-warning"

### DIFF
--- a/include/sndfile.hh
+++ b/include/sndfile.hh
@@ -57,12 +57,6 @@
 #include <string>
 #include <new> // for std::nothrow
 
-#if __cplusplus < 201100
-#ifndef nullptr
-#define nullptr NULL
-#endif
-#endif
-
 class SndfileHandle
 {	private :
 		struct SNDFILE_ref
@@ -78,7 +72,7 @@ class SndfileHandle
 
 	public :
 			/* Default constructor */
-			SndfileHandle (void) : p (nullptr) {} ;
+			SndfileHandle (void) : p (NULL) {} ;
 			SndfileHandle (const char *path, int mode = SFM_READ,
 							int format = 0, int channels = 0, int samplerate = 0) ;
 			SndfileHandle (std::string const & path, int mode = SFM_READ,
@@ -99,9 +93,9 @@ class SndfileHandle
 			SndfileHandle & operator = (const SndfileHandle &rhs) ;
 
 		/* Mainly for debugging/testing. */
-		int refCount (void) const { return (p == nullptr) ? 0 : p->ref ; }
+		int refCount (void) const { return (p == NULL) ? 0 : p->ref ; }
 
-		operator bool () const { return (p != nullptr) ; }
+		operator bool () const { return (p != NULL) ; }
 
 		bool operator == (const SndfileHandle &rhs) const { return (p == rhs.p) ; }
 
@@ -161,20 +155,20 @@ class SndfileHandle
 
 inline
 SndfileHandle::SNDFILE_ref::SNDFILE_ref (void)
-: sf (nullptr), sfinfo (), ref (1)
+: sf (NULL), sfinfo (), ref (1)
 {}
 
 inline
 SndfileHandle::SNDFILE_ref::~SNDFILE_ref (void)
-{	if (sf != nullptr) sf_close (sf) ; }
+{	if (sf != NULL) sf_close (sf) ; }
 
 inline
 SndfileHandle::SndfileHandle (const char *path, int mode, int fmt, int chans, int srate)
-: p (nullptr)
+: p (NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != nullptr)
+	if (p != NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -192,11 +186,11 @@ SndfileHandle::SndfileHandle (const char *path, int mode, int fmt, int chans, in
 
 inline
 SndfileHandle::SndfileHandle (std::string const & path, int mode, int fmt, int chans, int srate)
-: p (nullptr)
+: p (NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != nullptr)
+	if (p != NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -214,14 +208,14 @@ SndfileHandle::SndfileHandle (std::string const & path, int mode, int fmt, int c
 
 inline
 SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int chans, int srate)
-: p (nullptr)
+: p (NULL)
 {
 	if (fd < 0)
 		return ;
 
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != nullptr)
+	if (p != NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -239,11 +233,11 @@ SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int ch
 
 inline
 SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mode, int fmt, int chans, int srate)
-: p (nullptr)
+: p (NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != nullptr)
+	if (p != NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -261,7 +255,7 @@ SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mod
 
 inline
 SndfileHandle::~SndfileHandle (void)
-{	if (p != nullptr && -- p->ref == 0)
+{	if (p != NULL && -- p->ref == 0)
 		delete p ;
 } /* SndfileHandle destructor */
 
@@ -269,7 +263,7 @@ SndfileHandle::~SndfileHandle (void)
 inline
 SndfileHandle::SndfileHandle (const SndfileHandle &orig)
 : p (orig.p)
-{	if (p != nullptr)
+{	if (p != NULL)
 		++ p->ref ;
 } /* SndfileHandle copy constructor */
 
@@ -278,11 +272,11 @@ SndfileHandle::operator = (const SndfileHandle &rhs)
 {
 	if (&rhs == this)
 		return *this ;
-	if (p != nullptr && -- p->ref == 0)
+	if (p != NULL && -- p->ref == 0)
 		delete p ;
 
 	p = rhs.p ;
-	if (p != nullptr)
+	if (p != NULL)
 		++ p->ref ;
 
 	return *this ;
@@ -407,18 +401,18 @@ SndfileHandle::writeRaw (const void *ptr, sf_count_t bytes)
 
 inline SNDFILE *
 SndfileHandle::rawHandle (void)
-{	return (p ? p->sf : nullptr) ; }
+{	return (p ? p->sf : NULL) ; }
 
 inline SNDFILE *
 SndfileHandle::takeOwnership (void)
 {
-	if (p == nullptr || (p->ref != 1))
-		return nullptr ;
+	if (p == NULL || (p->ref != 1))
+		return NULL ;
 
 	SNDFILE * sf = p->sf ;
-	p->sf = nullptr ;
+	p->sf = NULL ;
 	delete p ;
-	p = nullptr ;
+	p = NULL ;
 	return sf ;
 }
 
@@ -426,11 +420,11 @@ SndfileHandle::takeOwnership (void)
 
 inline
 SndfileHandle::SndfileHandle (const wchar_t *wpath, int mode, int fmt, int chans, int srate)
-: p (nullptr)
+: p (NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != nullptr)
+	if (p != NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;

--- a/include/sndfile.hh
+++ b/include/sndfile.hh
@@ -47,6 +47,8 @@
 **
 ** API documentation is in the doc/ directory of the source code tarball
 ** and at http://libsndfile.github.io/libsndfile/api.html.
+**
+** This file is intended to compile with C++98 and newer.
 */
 
 #ifndef SNDFILE_HH

--- a/include/sndfile.hh
+++ b/include/sndfile.hh
@@ -57,6 +57,12 @@
 #include <string>
 #include <new> // for std::nothrow
 
+#if ((defined (_MSC_VER) && (_MSC_VER >= 1600)) || (__cplusplus >= 201100L))
+#define SF_NULL nullptr
+#else
+#define SF_NULL NULL
+#endif
+
 class SndfileHandle
 {	private :
 		struct SNDFILE_ref
@@ -72,7 +78,7 @@ class SndfileHandle
 
 	public :
 			/* Default constructor */
-			SndfileHandle (void) : p (NULL) {} ;
+			SndfileHandle (void) : p (SF_NULL) {} ;
 			SndfileHandle (const char *path, int mode = SFM_READ,
 							int format = 0, int channels = 0, int samplerate = 0) ;
 			SndfileHandle (std::string const & path, int mode = SFM_READ,
@@ -93,9 +99,9 @@ class SndfileHandle
 			SndfileHandle & operator = (const SndfileHandle &rhs) ;
 
 		/* Mainly for debugging/testing. */
-		int refCount (void) const { return (p == NULL) ? 0 : p->ref ; }
+		int refCount (void) const { return (p == SF_NULL) ? 0 : p->ref ; }
 
-		operator bool () const { return (p != NULL) ; }
+		operator bool () const { return (p != SF_NULL) ; }
 
 		bool operator == (const SndfileHandle &rhs) const { return (p == rhs.p) ; }
 
@@ -155,20 +161,20 @@ class SndfileHandle
 
 inline
 SndfileHandle::SNDFILE_ref::SNDFILE_ref (void)
-: sf (NULL), sfinfo (), ref (1)
+: sf (SF_NULL), sfinfo (), ref (1)
 {}
 
 inline
 SndfileHandle::SNDFILE_ref::~SNDFILE_ref (void)
-{	if (sf != NULL) sf_close (sf) ; }
+{	if (sf != SF_NULL) sf_close (sf) ; }
 
 inline
 SndfileHandle::SndfileHandle (const char *path, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (SF_NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != SF_NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -186,11 +192,11 @@ SndfileHandle::SndfileHandle (const char *path, int mode, int fmt, int chans, in
 
 inline
 SndfileHandle::SndfileHandle (std::string const & path, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (SF_NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != SF_NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -208,14 +214,14 @@ SndfileHandle::SndfileHandle (std::string const & path, int mode, int fmt, int c
 
 inline
 SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (SF_NULL)
 {
 	if (fd < 0)
 		return ;
 
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != SF_NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -233,11 +239,11 @@ SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int ch
 
 inline
 SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (SF_NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != SF_NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -255,7 +261,7 @@ SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mod
 
 inline
 SndfileHandle::~SndfileHandle (void)
-{	if (p != NULL && -- p->ref == 0)
+{	if (p != SF_NULL && -- p->ref == 0)
 		delete p ;
 } /* SndfileHandle destructor */
 
@@ -263,7 +269,7 @@ SndfileHandle::~SndfileHandle (void)
 inline
 SndfileHandle::SndfileHandle (const SndfileHandle &orig)
 : p (orig.p)
-{	if (p != NULL)
+{	if (p != SF_NULL)
 		++ p->ref ;
 } /* SndfileHandle copy constructor */
 
@@ -272,11 +278,11 @@ SndfileHandle::operator = (const SndfileHandle &rhs)
 {
 	if (&rhs == this)
 		return *this ;
-	if (p != NULL && -- p->ref == 0)
+	if (p != SF_NULL && -- p->ref == 0)
 		delete p ;
 
 	p = rhs.p ;
-	if (p != NULL)
+	if (p != SF_NULL)
 		++ p->ref ;
 
 	return *this ;
@@ -401,18 +407,18 @@ SndfileHandle::writeRaw (const void *ptr, sf_count_t bytes)
 
 inline SNDFILE *
 SndfileHandle::rawHandle (void)
-{	return (p ? p->sf : NULL) ; }
+{	return (p ? p->sf : SF_NULL) ; }
 
 inline SNDFILE *
 SndfileHandle::takeOwnership (void)
 {
-	if (p == NULL || (p->ref != 1))
-		return NULL ;
+	if (p == SF_NULL || (p->ref != 1))
+		return SF_NULL ;
 
 	SNDFILE * sf = p->sf ;
-	p->sf = NULL ;
+	p->sf = SF_NULL ;
 	delete p ;
-	p = NULL ;
+	p = SF_NULL ;
 	return sf ;
 }
 
@@ -420,11 +426,11 @@ SndfileHandle::takeOwnership (void)
 
 inline
 SndfileHandle::SndfileHandle (const wchar_t *wpath, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (SF_NULL)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != SF_NULL)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;


### PR DESCRIPTION
This reverts commit 2269af84173c1f70b6d700fa167e1e8ea01d7247.

The code which defined nullptr mysteriously broke the Windows build for
SuperCollider. After some investigation I discovered this commit to be the
cause, as MSVC by default does not set __cplusplus to anything greater
than 199711L unless explicitly asked to.

In general, #defining a keyword like nullptr in a library header is not
courteous, as it can affect compilation of later code and cause
significant confusion. This was exactly the situation I encountered, and
it took several days to track down the source.

The stated reason for the commit reverted by this was to prevent a
specific warning from appearing during compilation. However, there are
a few less intrusive ways of accomplishing this. For example, by using
`#pragma`s offered by all major compilers which temporarily disable
warnings, or by including headers with `-isystem` or any similar
mechanism which disables warnings from "system" headers. For code which
is intended to support C++98 and newer standards, preventing all
compilers from emitting any warnings is a losing battle. It is easier
in my view for consuming code to handle this as it needs to.

There are several options here for resolving this. I could just fix my
project, but that would not prevent others from encountering the same
issue. I could try for a clever-er version of this using a macro not
named nullptr and an additional check for MSVC, but this seems to offer
diminishing returns considering how easily any warnings about NULL can
be silenced, and carries the risk of introducing new and unforeseen
problems. So, I have here simply reverted the commit so the code uses
NULL once again.

---

I'm happy to discuss alternate ways of solving this. I guess I would first ask whether this header needs to support C++98 at all? It doesn't seem to be stated explicitly.