### PR TITLE
WIP: Support MPEG Layer 3 in WAV

### DIFF
--- a/src/mpeg_decode.c
+++ b/src/mpeg_decode.c
@@ -568,7 +568,6 @@ mpeg_decoder_init (SF_PRIVATE *psf)
 	mpg123_param (pmp3d->pmh, MPG123_ADD_FLAGS, MPG123_NO_FRANKENSTEIN, 1.0) ;
 #endif
 
-	psf->dataoffset = 0 ;
 	/*
 	** Need to pass the first MPEG frame to libmpg123, but that frame was read
 	** into psf->binheader in order that we could identify the stream.
@@ -578,8 +577,8 @@ mpeg_decoder_init (SF_PRIVATE *psf)
 		** Can't seek, so setup our libmpg123 io callbacks to read the binheader
 		** buffer first.
 		*/
-		psf_binheader_readf (psf, "p", 0) ;
-		pmp3d->header_remaining = psf_binheader_readf (psf, NULL) ;
+		psf_binheader_readf (psf, "p", psf->dataoffset) ;
+		pmp3d->header_remaining = psf_binheader_readf (psf, NULL) - psf->dataoffset ;
 
 		/* Tell libmpg123 we can't seek the file. */
 		mpg123_param (pmp3d->pmh, MPG123_ADD_FLAGS, MPG123_NO_PEEK_END, 1.0) ;

--- a/src/mpeg_l3_encode.c
+++ b/src/mpeg_l3_encode.c
@@ -496,11 +496,11 @@ mpeg_l3_encode_write_short_stereo (SF_PRIVATE *psf, const short *ptr, sf_count_t
 	MPEG_L3_ENC_PRIVATE *pmpeg = (MPEG_L3_ENC_PRIVATE*) psf->codec_data ;
 	sf_count_t total = 0 ;
 	int nbytes, writecount, writen ;
-	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.sbuf), pmpeg->frame_samples) ;
 
 	if ((psf->error = mpeg_l3_encoder_construct (psf)))
 		return 0 ;
 
+	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.sbuf), pmpeg->frame_samples) ;
 	while (len)
 	{	writecount = SF_MIN (len, max_samples) ;
 		/*
@@ -645,11 +645,11 @@ mpeg_l3_encode_write_float_stereo (SF_PRIVATE *psf, const float *ptr, sf_count_t
 	MPEG_L3_ENC_PRIVATE *pmpeg = (MPEG_L3_ENC_PRIVATE*) psf->codec_data ;
 	sf_count_t total = 0 ;
 	int nbytes, writecount, writen ;
-	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.fbuf), pmpeg->frame_samples) ;
 
 	if ((psf->error = mpeg_l3_encoder_construct (psf)))
 		return 0 ;
 
+	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.fbuf), pmpeg->frame_samples) ;
 	while (len)
 	{	writecount = SF_MIN (len, max_samples) ;
 
@@ -695,11 +695,11 @@ mpeg_l3_encode_write_double_mono (SF_PRIVATE *psf, const double *ptr, sf_count_t
 	MPEG_L3_ENC_PRIVATE *pmpeg = (MPEG_L3_ENC_PRIVATE*) psf->codec_data ;
 	sf_count_t total = 0 ;
 	int nbytes, writecount, writen ;
-	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.dbuf), pmpeg->frame_samples) ;
 
 	if ((psf->error = mpeg_l3_encoder_construct (psf)))
 		return 0 ;
 
+	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.dbuf), pmpeg->frame_samples) ;
 	while (len)
 	{	writecount = SF_MIN (len, max_samples) ;
 
@@ -737,11 +737,11 @@ mpeg_l3_encode_write_double_stereo (SF_PRIVATE *psf, const double *ptr, sf_count
 	MPEG_L3_ENC_PRIVATE *pmpeg = (MPEG_L3_ENC_PRIVATE*) psf->codec_data ;
 	sf_count_t total = 0 ;
 	int nbytes, writecount, writen ;
-	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.dbuf), pmpeg->frame_samples) ;
 
 	if ((psf->error = mpeg_l3_encoder_construct (psf)))
 		return 0 ;
 
+	const sf_count_t max_samples = SF_MIN (ARRAY_LEN (ubuf.dbuf), pmpeg->frame_samples) ;
 	while (len)
 	{	writecount = SF_MIN (len, max_samples) ;
 

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -691,6 +691,8 @@ sf_format_check	(const SF_INFO *info)
 				if ((subformat == SF_FORMAT_NMS_ADPCM_16 || subformat == SF_FORMAT_NMS_ADPCM_24 ||
 							subformat == SF_FORMAT_NMS_ADPCM_32) && info->channels == 1)
 					return 1 ;
+				if (subformat == SF_FORMAT_MPEG_LAYER_III && info->channels <= 2)
+					return 1 ;
 				break ;
 
 		case SF_FORMAT_WAVEX :

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -173,6 +173,7 @@ wavlike_read_fmt_chunk (SF_PRIVATE *psf, int fmtsize)
 	{	switch (wav_fmt->format)
 		{	case WAVE_FORMAT_GSM610 :
 			case WAVE_FORMAT_IPP_ITU_G_723_1 :
+			case WAVE_FORMAT_MPEGLAYER3 :
 					psf_log_printf (psf, "  Bit Width     : %d\n", wav_fmt->min.bitwidth) ;
 					break ;
 			default :
@@ -183,7 +184,8 @@ wavlike_read_fmt_chunk (SF_PRIVATE *psf, int fmtsize)
 	{	switch (wav_fmt->format)
 		{	case WAVE_FORMAT_GSM610 :
 			case WAVE_FORMAT_IPP_ITU_G_723_1 :
-		psf_log_printf (psf, "  Bit Width     : %d (should be 0)\n", wav_fmt->min.bitwidth) ;
+			case WAVE_FORMAT_MPEGLAYER3 :
+					psf_log_printf (psf, "  Bit Width     : %d (should be 0)\n", wav_fmt->min.bitwidth) ;
 					break ;
 			default :
 					psf_log_printf (psf, "  Bit Width     : %d\n", wav_fmt->min.bitwidth) ;
@@ -304,6 +306,23 @@ wavlike_read_fmt_chunk (SF_PRIVATE *psf, int fmtsize)
 
 				psf_log_printf (psf, "  Extra Bytes   : %d\n", wav_fmt->gsm610.extrabytes) ;
 				psf_log_printf (psf, "  Samples/Block : %d\n", wav_fmt->gsm610.samplesperblock) ;
+				break ;
+
+		case WAVE_FORMAT_MPEGLAYER3 :
+				bytesread += psf_binheader_readf (psf, "24222", &(wav_fmt->mpeg3.extrabytes),
+					&(wav_fmt->mpeg3.id), &(wav_fmt->mpeg3.flags), &(wav_fmt->mpeg3.blocksize),
+					&(wav_fmt->mpeg3.samplesperblock), &(wav_fmt->mpeg3.codecdelay)) ;
+
+				psf_log_printf (psf, "  Bytes/sec     : %d\n", wav_fmt->mpeg3.bytespersec) ;
+				psf_log_printf (psf, "  Extra Bytes   : %d\n", wav_fmt->mpeg3.extrabytes) ;
+				if (wav_fmt->mpeg3.id != 1)
+					psf_log_printf (psf, "  ID            : %d (unknown, should be 1)\n", wav_fmt->mpeg3.id) ;
+				else
+					psf_log_printf (psf, "  ID            : MPEGLAYER3_ID_MPEG\n") ;
+				psf_log_printf (psf, "  Flags         : 0x%08x\n", wav_fmt->mpeg3.flags) ;
+				psf_log_printf (psf, "  Block Size    : %d\n", wav_fmt->mpeg3.blocksize) ;
+				psf_log_printf (psf, "  Samples/Block : %d\n", wav_fmt->mpeg3.samplesperblock) ;
+				psf_log_printf (psf, "  Codec Delay   : %d samples\n", wav_fmt->mpeg3.codecdelay) ;
 				break ;
 
 		case WAVE_FORMAT_EXTENSIBLE :

--- a/src/wavlike.h
+++ b/src/wavlike.h
@@ -264,6 +264,21 @@ typedef	struct
 } GSM610_WAV_FMT ;
 
 typedef struct
+{	unsigned short	format ;
+	unsigned short	channels ;
+	unsigned int	samplerate ;
+	unsigned int	bytespersec ;
+	unsigned short	blockalign ;
+	unsigned short	bitwidth ;
+	unsigned short	extrabytes ;
+	unsigned short	id ;
+	unsigned int	flags ;
+	unsigned short	blocksize ;
+	unsigned short	samplesperblock ;
+	unsigned short	codecdelay ;
+} MPEGLAYER3_WAV_FMT ;
+
+typedef struct
 {	unsigned int	esf_field1 ;
 	unsigned short	esf_field2 ;
 	unsigned short	esf_field3 ;
@@ -291,6 +306,7 @@ typedef union
 	G72x_ADPCM_WAV_FMT	g72x ;
 	EXTENSIBLE_WAV_FMT	ext ;
 	GSM610_WAV_FMT		gsm610 ;
+	MPEGLAYER3_WAV_FMT	mpeg3 ;
 	WAV_FMT_SIZE20		size20 ;
 	char				padding [512] ;
 } WAV_FMT ;


### PR DESCRIPTION
# Support for MPEGLAYER3WAVEFORMAT.

MPEGLAYER3WAVEFORMAT is a method to embed a MPEG layer III audio stream inside of a Wav file. This is a long-existent format, created sometime around Windows 95. The format allows for VBR streams, and includes important information about the stream for gapless playback that was later solved by Info/Xing header it predates.

Many mp3 files are actually embedded inside of a WAV file. Because of the frame sync and junk tolerance of MPEG decoders, most of such files are suffixed with ".mp3" and will usually work just fine with the MPEG decoder ignoring the RIFF part of the file. Users may not be aware that their mp3 file actually has a wav RIFF header.

This presents a problem for Libsndfile, which first tryies to detect known containers from their data signatures, regardless of suffix. When it sees a WAV RIFF header it will try and parse the file as a WAV file but then fail for lack of support for MPEGLAYER3WAVEFORMAT.

This PR adds support for reading and writing the MPEG_LAYER_III subformat in the WAV container.

## TODO
- [x] MPEGLAYER3 fmt parsing
- [ ]  MPEGLAYER3 fmt writing
  - [ ] Plumb through details from `mpeg_l3_encoder.c`
- [ ] Modify MPEG and WAV Tests
- [ ] Support for Gapless decoding using WAV header metadata instead of Info/Xing header metadata. (Will require coordination with mpg123 upstream.)