### PR TITLE
Programs: Add MPEG functionality, Vorbis, Opus fixes

### DIFF
--- a/programs/common.c
+++ b/programs/common.c
@@ -73,7 +73,7 @@ sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize
 			{	data [k] /= max ;
 
 				if (!isfinite (data [k])) /* infinite or NaN */
-					return 1;
+					return 1 ;
 				}
 			sf_writef_double (outfile, data, readcount) ;
 			} ;
@@ -119,6 +119,7 @@ merge_broadcast_info (SNDFILE * infile, SNDFILE * outfile, int format, const MET
 	{	case SF_FORMAT_PCM_16 :
 		case SF_FORMAT_PCM_24 :
 		case SF_FORMAT_PCM_32 :
+		case SF_FORMAT_MPEG_LAYER_III :
 			break ;
 
 		default :
@@ -339,8 +340,8 @@ static OUTPUT_FORMAT_MAP format_map [] =
 	{	"caf",		0,	SF_FORMAT_CAF	},
 	{	"wve",		0,	SF_FORMAT_WVE	},
 	{	"prc",		0,	SF_FORMAT_WVE	},
-	{	"ogg",		0,	SF_FORMAT_OGG	},
 	{	"oga",		0,	SF_FORMAT_OGG	},
+	{	"ogg",		0,	SF_FORMAT_OGG | SF_FORMAT_VORBIS },
 	{	"opus",		0,	SF_FORMAT_OGG | SF_FORMAT_OPUS },
 	{	"mpc",		0,	SF_FORMAT_MPC2K	},
 	{	"rf64",		0,	SF_FORMAT_RF64	},
@@ -454,6 +455,7 @@ sfe_container_name (int format)
 		case SF_FORMAT_OGG : return "OGG" ;
 		case SF_FORMAT_MPC2K : return "MPC2K" ;
 		case SF_FORMAT_RF64 : return "RF64" ;
+		case SF_FORMAT_MPEG : return "MPEG" ;
 		default : break ;
 		} ;
 
@@ -492,6 +494,9 @@ sfe_codec_name (int format)
 		case SF_FORMAT_ALAC_24 : return "24 bit ALAC" ;
 		case SF_FORMAT_ALAC_32 : return "32 bit ALAC" ;
 		case SF_FORMAT_OPUS : return "Opus" ;
+		case SF_FORMAT_MPEG_LAYER_I : return "MPEG layer 1" ;
+		case SF_FORMAT_MPEG_LAYER_II : return "MPEG layer 2" ;
+		case SF_FORMAT_MPEG_LAYER_III : return "MPEG layer 3" ;
 		default : break ;
 		} ;
 	return "unknown" ;

--- a/programs/sndfile-convert.c
+++ b/programs/sndfile-convert.c
@@ -354,7 +354,10 @@ main (int argc, char * argv [])
 			|| (outfileminor == SF_FORMAT_DOUBLE) || (outfileminor == SF_FORMAT_FLOAT)
 			|| (infileminor == SF_FORMAT_DOUBLE) || (infileminor == SF_FORMAT_FLOAT)
 			|| (infileminor == SF_FORMAT_OPUS) || (outfileminor == SF_FORMAT_OPUS)
-			|| (infileminor == SF_FORMAT_VORBIS) || (outfileminor == SF_FORMAT_VORBIS))
+			|| (infileminor == SF_FORMAT_VORBIS) || (outfileminor == SF_FORMAT_VORBIS)
+			|| (infileminor == SF_FORMAT_MPEG_LAYER_I)
+			|| (infileminor == SF_FORMAT_MPEG_LAYER_II)
+			|| (infileminor == SF_FORMAT_MPEG_LAYER_III) || (outfileminor == SF_FORMAT_MPEG_LAYER_III))
 	{	if (sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) != 0)
 		{	printf ("Error : Not able to decode input file %s.\n", infilename) ;
 			return 1 ;

--- a/programs/sndfile-info.c
+++ b/programs/sndfile-info.c
@@ -167,6 +167,8 @@ calc_decibels (SF_INFO * sfinfo, double max)
 
 		case SF_FORMAT_FLOAT :
 		case SF_FORMAT_DOUBLE :
+		case SF_FORMAT_VORBIS :
+		case SF_FORMAT_OPUS :
 			decibels = max / 1.0 ;
 			break ;
 

--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -410,10 +410,10 @@ static void
 opus_print_header (SF_PRIVATE *psf, OpusHeader *h)
 {	psf_log_printf (psf, "Opus Header Metadata\n") ;
 	psf_log_printf (psf, "  OggOpus version  : %d\n", h->version) ;
-	psf_log_printf (psf, "  Channels		 : %d\n", h->channels) ;
-	psf_log_printf (psf, "  Preskip		  : %d samples @48kHz\n", h->preskip) ;
+	psf_log_printf (psf, "  Channels         : %d\n", h->channels) ;
+	psf_log_printf (psf, "  Preskip          : %d samples @48kHz\n", h->preskip) ;
 	psf_log_printf (psf, "  Input Samplerate : %d Hz\n", h->input_samplerate) ;
-	psf_log_printf (psf, "  Gain			 : %d.%d\n", arith_shift_right (h->gain & 0xF0, 8), h->gain & 0x0F) ;
+	psf_log_printf (psf, "  Gain             : %d.%d\n", arith_shift_right (h->gain & 0xF0, 8), h->gain & 0x0F) ;
 	psf_log_printf (psf, "  Channel Mapping  : ") ;
 	switch (h->channel_mapping)
 	{	case 0 :	psf_log_printf (psf, "0 (mono or stereo)\n") ; break ;
@@ -426,7 +426,7 @@ opus_print_header (SF_PRIVATE *psf, OpusHeader *h)
 	{	int i ;
 		psf_log_printf (psf, "   streams total   : %d\n", h->nb_streams) ;
 		psf_log_printf (psf, "   streams coupled : %d\n", h->nb_coupled) ;
-		psf_log_printf (psf, "	stream mapping : [") ;
+		psf_log_printf (psf, "   stream mapping : [") ;
 		for (i = 0 ; i < h->channels - 1 ; i++)
 			psf_log_printf (psf, "%d,", h->stream_map [i]) ;
 		psf_log_printf (psf, "%d]\n", h->stream_map [i]) ;


### PR DESCRIPTION
A few small fixes for the programs.

 - (common) Add missing MPEG format handling in to string conversions.
 - (common) Fix a style error that was somehow committed already!?
 - (convert) Do floating point sample copying when either the source or destination is MPEG
 - (convert) Infer Vorbis subformat from `.ogg` suffix. This aligns with what Xiph.org now recommends. `.oga` still means "Ogg container with audio" and is subformat agnostic.
 - (common) Don't warn about Broadcast Chunk for MPEG WAV files. By the comment above, they are allowed by the RFC.
 - (info) Calculate dB properly for Vorbis and Opus.

One non-program fix that's been bugging me for a while:
 - For Opus, remove tabs injected into a pre-formated info-dump block of printfs, messing up the alignment.