### PR TITLE
Fix heap-buffer-overflow in copyPredictorTo24

### DIFF
--- a/src/ALAC/alac_decoder.c
+++ b/src/ALAC/alac_decoder.c
@@ -554,7 +554,7 @@ alac_decode (ALAC_DECODER *p, struct BitBuffer * bits, int32_t * sampleBuffer, u
 			}
 		}
 
-#if 0 // ! DEBUG
+#if 1 // ! DEBUG
 		// if we've decoded all of our channels, bail (but not in debug b/c we want to know if we're seeing bad bits)
 		// - this also protects us if the config does not match the bitstream or crap data bits follow the audio bits
 		if (channelIndex >= numChannels)


### PR DESCRIPTION
This PR fixes the crash seen in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27503 by re-enabling code that shouldn't have been disabled in the original import. AFAICT this is the original code: https://github.com/macosforge/alac/blob/master/codec/ALACDecoder.cpp#L588-L593. However since we're importing this we would want it to be in release mode with this check enabled by default. Without this check `channelIndex` can increase without bounds and that leads to writing past the end of the output buffer.