### PR TITLE
pcm: Speep up s2lei_array()

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -570,16 +570,9 @@ s2bet_array (const short *src, tribyte *dest, int count)
 
 static inline void
 s2lei_array (const short *src, int *dest, int count)
-{	unsigned char	*ucptr ;
-
-	ucptr = ((unsigned char*) dest) + 4 * count ;
-	while (--count >= 0)
-	{	ucptr -= 4 ;
-		ucptr [0] = 0 ;
-		ucptr [1] = 0 ;
-		ucptr [2] = src [count] ;
-		ucptr [3] = src [count] >> 8 ;
-		} ;
+{
+	for (int i = 0 ; i < count ; i++)
+		dest [i] = arith_shift_left (src [i], 16) ;
 } /* s2lei_array */
 
 static inline void


### PR DESCRIPTION
# Description

Simpler code, faster execution, better auto vectorization.

# Generated code

https://godbolt.org/z/d9T5h9sqP

# Benchmark results

## MSVC 2019 16.9 /O2:

|Benchmark               | Time    | CPU     | Iterations         |
| ---------------------- | ------- | ------- | ------------------ |
| BM_s2lei_array         | 280 ns  | 276 ns  | 2036364            |
| BM_s2lei_array_opt     | 160 ns  | 157 ns  | 4977778            |
| BM_s2lei_array_opt_for | 44.6 ns | 44.3 ns | 14451613           |

## GCC 9.3.0 -O2:

|Benchmark               | Time    | CPU     | Iterations         |
| ---------------------- | ------- | ------- | ------------------ |
| BM_s2lei_array         | 341 ns  | 337 ns  | 1947826            |
| BM_s2lei_array_opt     | 246 ns  | 246 ns  | 2800000            |
| BM_s2lei_array_opt_for | 240 ns  | 240 ns  | 2800000            |

## GCC 9.3.0 -O3:

|Benchmark               | Time    | CPU     | Iterations         |
| ---------------------- | ------- | ------- | ------------------ |
| BM_s2lei_array         | 345 ns  | 345 ns  | 2036364            |
| BM_s2lei_array_opt     | 246 ns  | 246 ns  | 2800000            |
| BM_s2lei_array_opt_for | 89.5 ns | 87.9 ns | 7466667            |

## Clang 10.0.0 -O2:

|Benchmark               | Time    | CPU     | Iterations         |
| ---------------------- | ------- | ------- | ------------------ |
| BM_s2lei_array         | 140 ns  | 140 ns  |     4480000        |
| BM_s2lei_array_opt     | 42.2 ns | 42.4 ns |    16592593        |
| BM_s2lei_array_opt_for | 27.4 ns | 27.3 ns |    26352941        |

## Clang 10.0.0 -O3:

|Benchmark               | Time    | CPU     | Iterations         |
| ---------------------- | ------- | ------- | ------------------ |
| BM_s2lei_array         | 138 ns  | 138 ns  |  4977778           |
| BM_s2lei_array_opt     | 42.5 ns | 42.4 ns | 16592593           |
| BM_s2lei_array_opt_for | 26.0 ns | 24.9 ns | 26352941           |
