### PR TITLE
Prevent underflow/overflow when decoding OGG Vorbis to int16

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -996,6 +996,11 @@ static inline int psf_lrint (double x)
 ** Other helper functions.
 */
 
+static inline float clampf (float x, float min, float max)
+{
+	return x < min ? min : x > max ? max : x ;
+}
+
 void	*psf_memset (void *s, int c, sf_count_t n) ;
 
 SF_CUES * psf_cues_dup (const void * ptr, size_t datasize) ;

--- a/src/ogg_vorbis.c
+++ b/src/ogg_vorbis.c
@@ -552,13 +552,19 @@ vorbis_rshort (SF_PRIVATE *psf, int samples, void *vptr, int off, int channels, 
 		float inverse = 1.0 / psf->float_max ;
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-				ptr [i++] = psf_lrintf ((pcm [n][j] * inverse) * 32767.0f) ;
+			{
+				int x = psf_lrintf ((pcm [n][j] * inverse) * 32767.0f) ;
+				ptr [i++] = x > SHRT_MAX ? SHRT_MAX : x < SHRT_MIN ? SHRT_MIN : x ;
+			}
 	}
 	else
 	{
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-				ptr [i++] = psf_lrintf (pcm [n][j] * 32767.0f) ;
+			{
+				int x = psf_lrintf (pcm [n][j] * 32767.0f) ;
+				ptr [i++] = x > SHRT_MAX ? SHRT_MAX : x < SHRT_MIN ? SHRT_MIN : x ;
+			}
 	}
 	return i ;
 } /* vorbis_rshort */

--- a/src/ogg_vorbis.c
+++ b/src/ogg_vorbis.c
@@ -552,19 +552,13 @@ vorbis_rshort (SF_PRIVATE *psf, int samples, void *vptr, int off, int channels, 
 		float inverse = 1.0 / psf->float_max ;
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-			{
-				int x = psf_lrintf ((pcm [n][j] * inverse) * 32767.0f) ;
-				ptr [i++] = x > SHRT_MAX ? SHRT_MAX : x < SHRT_MIN ? SHRT_MIN : x ;
-			}
+				ptr [i++] = psf_lrintf (clampf (pcm [n][j] * inverse, -1, 1) * 32767.0f) ;
 	}
 	else
 	{
 		for (j = 0 ; j < samples ; j++)
 			for (n = 0 ; n < channels ; n++)
-			{
-				int x = psf_lrintf (pcm [n][j] * 32767.0f) ;
-				ptr [i++] = x > SHRT_MAX ? SHRT_MAX : x < SHRT_MIN ? SHRT_MIN : x ;
-			}
+				ptr [i++] = psf_lrintf (clampf (pcm [n][j], -1, 1) * 32767.0f) ;
 	}
 	return i ;
 } /* vorbis_rshort */


### PR DESCRIPTION
It fixes overflow/underflow issues bug when decoding OGG Vorbis directly to int16.
The applied solution consists on first rounding to int, then clamping the value to the range of int16.

Signed-off-by: Joaquin Anton <janton@nvidia.com>