### PR TITLE
Read CMake ABI version from configure.ac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,23 +18,6 @@ endif ()
 project(libsndfile VERSION 1.0.31)
 
 #
-# ABI version of library.
-#
-
-set (SNDFILE_ABI_VERSION_MAJOR 1)
-set (SNDFILE_ABI_VERSION_MINOR 0)
-set (SNDFILE_ABI_VERSION_PATCH 31)
-set (SNDFILE_ABI_VERSION "${SNDFILE_ABI_VERSION_MAJOR}.${SNDFILE_ABI_VERSION_MINOR}.${SNDFILE_ABI_VERSION_PATCH}")
-
-#
-# Apple platform current and compatibility versions.
-#
-
-math (EXPR SNDFILE_MACHO_CURRENT_VERSION_MAJOR "${SNDFILE_ABI_VERSION_MAJOR} + ${SNDFILE_ABI_VERSION_MINOR} + 1")
-set (SNDFILE_MACHO_CURRENT_VERSION "${SNDFILE_MACHO_CURRENT_VERSION_MAJOR}.${SNDFILE_ABI_VERSION_PATCH}.0")
-set (SNDFILE_MACHO_COMPATIBILITY_VERSION "${SNDFILE_MACHO_CURRENT_VERSION_MAJOR}.0.0")
-
-#
 # Variables
 #
 
@@ -405,6 +388,28 @@ if (ENABLE_COMPATIBLE_LIBSNDFILE_NAME)
 endif ()
 
 if (BUILD_SHARED_LIBS)
+
+	#
+	# ABI version of library.
+	#
+
+	#
+	# Read libtool version from `configure.ac` and set libsndfile ABI version:
+	#
+	#   SNDFILE_ABI_VERSION_MAJOR
+	#   SNDFILE_ABI_VERSION_MINOR
+	#   SNDFILE_ABI_VERSION_PATCH
+	#   SNDFILE_ABI_VERSION
+	#
+	# and Mach-O current and compatibility versions:
+	#
+	#   SNDFILE_MACHO_CURRENT_VERSION
+	#   SNDFILE_MACHO_COMPATIBILITY_VERSION
+	#
+
+	include (SetupABIVersions)
+
+	setup_abi_versions()
 
 	if (WIN32)
 		set (VERSION_MAJOR ${CPACK_PACKAGE_VERSION_MAJOR})

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,8 @@ cmake_files = cmake/ClipMode.cmake cmake/FindFLAC.cmake \
 	cmake/SndFileChecks.cmake cmake/TestInline.cmake \
 	cmake/TestLargeFiles.cmake cmake/TestInline.c.in \
 	cmake/FindOpus.cmake cmake/SndFileConfig.cmake.in \
-	cmake/CheckCPUArch.cmake cmake/CheckCPUArch.c.in
+	cmake/CheckCPUArch.cmake cmake/CheckCPUArch.c.in \
+	cmake/SetupABIVersions.cmake
 
 pkgconfig_DATA = sndfile.pc
 

--- a/cmake/SetupABIVersions.cmake
+++ b/cmake/SetupABIVersions.cmake
@@ -1,0 +1,56 @@
+# Inspiration: https://github.com/ros2-dotnet/Fast-RTPS
+
+macro (SETUP_ABI_VERSIONS)
+
+    file (STRINGS ${PROJECT_SOURCE_DIR}/configure.ac CONFIGURE_AC_CONTENT)
+    file (STRINGS
+        configure.ac
+        SNDFILE_LT_CURRENT_TMP
+        REGEX "^m4_define\\(\\[?lt_current\\]?, *\\[?[0-9]+\\]?\\)"
+        )
+    string (REGEX REPLACE "m4_define\\(\\[?lt_current\\]?, *\\[?([0-9]+)\\]?\\)"
+        "\\1"
+        SNDFILE_LT_CURRENT
+        ${SNDFILE_LT_CURRENT_TMP}
+        )
+
+    file (STRINGS
+        configure.ac
+        SNDFILE_LT_REVISION_TMP
+        REGEX "^m4_define\\(\\[?lt_revision\\]?, *\\[?[0-9]+\\]?\\)"
+        )
+    string (REGEX REPLACE "m4_define\\(\\[?lt_revision\\]?, *\\[?([0-9]+)\\]?\\)"
+        "\\1"
+        SNDFILE_LT_REVISION
+        ${SNDFILE_LT_REVISION_TMP}
+        )
+
+    file (STRINGS
+        configure.ac
+        SNDFILE_LT_AGE_TMP
+        REGEX "^m4_define\\(\\[?lt_age\\]?, *\\[?[0-9]+\\]?\\)"
+        )
+    string (REGEX REPLACE "m4_define\\(\\[?lt_age\\]?, *\\[?([0-9]+)\\]?\\)"
+        "\\1"
+        SNDFILE_LT_AGE
+        ${SNDFILE_LT_AGE_TMP}
+        )
+
+    #
+    # Calculate CMake compatible ABI version from libtool version.
+    #
+
+    math (EXPR SNDFILE_ABI_VERSION_MAJOR "${SNDFILE_LT_CURRENT} - ${SNDFILE_LT_AGE}")
+    set (SNDFILE_ABI_VERSION_MINOR ${SNDFILE_LT_AGE})
+    set (SNDFILE_ABI_VERSION_PATCH ${SNDFILE_LT_REVISION})
+    set (SNDFILE_ABI_VERSION "${SNDFILE_ABI_VERSION_MAJOR}.${SNDFILE_ABI_VERSION_MINOR}.${SNDFILE_ABI_VERSION_PATCH}")
+
+    #
+    # Apple platform current and compatibility versions.
+    #
+
+    math (EXPR SNDFILE_MACHO_CURRENT_VERSION_MAJOR "${SNDFILE_ABI_VERSION_MAJOR} + ${SNDFILE_ABI_VERSION_MINOR} + 1")
+    set (SNDFILE_MACHO_CURRENT_VERSION "${SNDFILE_MACHO_CURRENT_VERSION_MAJOR}.${SNDFILE_ABI_VERSION_PATCH}.0")
+    set (SNDFILE_MACHO_COMPATIBILITY_VERSION "${SNDFILE_MACHO_CURRENT_VERSION_MAJOR}.0.0")
+
+endmacro (SETUP_ABI_VERSIONS)


### PR DESCRIPTION
This change will make release process easier - bump `lt_current`, `lt_revision` and `lt_age` in `configure.ac` and CMake will update ABI version on configure or build.