### PR TITLE
Fix duplicated case value of ESTRPIPE on BSD

### DIFF
--- a/programs/sndfile-play.c
+++ b/programs/sndfile-play.c
@@ -328,10 +328,12 @@ alsa_write_float (snd_pcm_t *alsa_dev, float *data, int frames, int channels)
 					return 0 ;
 					break ;
 
+#if defined ESTRPIPE && ESTRPIPE != EPIPE
 			case -ESTRPIPE :
 					fprintf (stderr, "alsa_write_float: Suspend event.n") ;
 					return 0 ;
 					break ;
+#endif
 
 			case -EIO :
 					puts ("alsa_write_float: EIO") ;


### PR DESCRIPTION
It was built with an error in FreeBSD:
```
programs/sndfile-play.c: In function 'alsa_write_float':
programs/sndfile-play.c:331:4: error: duplicate case value programs/sndfile-play.c:293:4: note: previously used here
```
because this file has defined `ESTRPIPE` as `EPIPE` in: `/usr/local/include/alsa/pcm.h:#define ESTRPIPE EPIPE`