### PR TITLE
configure.ac: trigger error & stop if not all Xiph libs available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,8 +392,7 @@ AS_IF([test -n "$PKG_CONFIG"], [
 					AC_MSG_WARN([[***]])
 					AC_MSG_WARN([[*** Unfortunately, for ease of maintenance, the external libs]])
 					AC_MSG_WARN([[*** are an all or nothing affair.]])
-					AS_ECHO([""])
-					enable_external_libs=no
+					AC_MSG_ERROR(["You requested external libraries, but not all were found"])
 				])
 	])
 


### PR DESCRIPTION
The context here is that I sent a patch to Yocto, to update the library
from 1.0.28 to 1.0.31 and move to the new URLs for libsndfile.

However, in the meantime, libsndfile also supports libopus and does not
allow support for libvorbis, libflac and libogg to be included if either of
these libs (and libopus) does not exist.

That's fine, but it allows for weird/silent failures that can slip through
when you're a package maintainer.

Which is what happened here:
  https://lists.openembedded.org/g/openembedded-core/message/162558?p=%2C%2C%2C20%2C0%2C0%2C0%3A%3Acreated%2C0%2Clibsndfile1%2C20%2C2%2C0%2C89367260

So, the idea is to propose that this build configuration should trigger a
fail that can be seen at build time and not be caught off-guard.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>