### PR TITLE
Only add `-Wno-format-truncation` when using GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -633,11 +633,22 @@ AS_IF([test "x$enable_werror" = "xyes"], [
 		AC_LANG_POP([C++])
 	])
 
-common_flags="-Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wshadow -Wwrite-strings -Wundef -Wuninitialized -Winit-self -Wno-format-truncation"
-AX_APPEND_COMPILE_FLAGS([${common_flags} -Wvla -Wbad-function-cast -Wnested-externs -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Waggregate-return], [CFLAGS])
+common_flags="-Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wshadow -Wwrite-strings -Wundef -Wuninitialized -Winit-self"
+common_cflags="${common_flags}"
+dnl Clang doesn't know about -Wno-format-truncation
+dnl and would spew tons of warnings otherwise.
+AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [
+		common_cflags+=" -Wno-format-truncation"
+	])
+common_cxxflags="${common_flags}"
+AS_IF([test "x$ax_cv_cxx_compiler_vendor" = "xgnu"], [
+		common_cxxflags+=" -Wno-format-truncation"
+	])
+
+AX_APPEND_COMPILE_FLAGS([${common_cflags} -Wvla -Wbad-function-cast -Wnested-externs -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Waggregate-return], [CFLAGS])
 
 AC_LANG_PUSH([C++])
-AX_APPEND_COMPILE_FLAGS([${common_flags} -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wreorder -Wsign-promo], [CXXFLAGS])
+AX_APPEND_COMPILE_FLAGS([${common_cxxflags} -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wreorder -Wsign-promo], [CXXFLAGS])
 AC_LANG_POP([C++])
 
 AS_IF([test "x$enable_test_coverage" = "xyes"], [


### PR DESCRIPTION
* Clang produces warnings such as
  warning: unknown warning option '-Wno-format-truncation' [-Wunknown-warning-option]