### PR TITLE
Support skipping large wav chunks on stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * CMake build from Autotools tarball (issue #816).
 * Build on UWP platform (issue #824).
 * Fix signed integer overflow (issue #785).
+* Skipping large wav chunks on stdin (PR #819).
 
 ## [1.1.0] - 2022-03-27
 


### PR DESCRIPTION
Some wav files can have rather large chunks with chunk types that are
not supported by libsndfile at all. For those, header_seek will just
skip the whole chunk.

This commit makes skipping the chunk work even if the input is stdin
(which doesn't support psf_fseek), by reading over the header using
psf_fread in that case.

______________________

I have a wav file here which has these chunks:
```
$ rifftree -s bug1.wav
RIFF(WAVE)-> (39882456 Bytes)
            fmt ; (16 Bytes)
            sav1; (42 Bytes)
            sav2; (4 Bytes)
            bext; (642 Bytes)
            pad ; (130308 Bytes)
            data; (39751396 Bytes)
```
Libsndfile can read this file correctly if I provide a filename to open it. If I read it from stdin, it doesn't work. I have added some debugging (`SFC_GET_LOG_INFO`) to my code, and here is the result for stdin:
```
$ cat bug1.wav | audiowmark add - out.wav f0
[[File : -
Length : unknown
RIFF : 39882460
WAVE
fmt  : 16
  Format        : 0x1 => WAVE_FORMAT_PCM
  Channels      : 2
  Sample Rate   : 44100
  Block Align   : 4
  Bit Width     : 16
  Bytes/sec     : 176400
*** sav1 : 42 (unknown marker)
*** sav2 : 4 (unknown marker)
bext : 642
*** pad  : 130308 (unknown marker)
Request for header allocation of 260616 denied.
psf_fseek : pipe seek to value other than pipeoffset
Have 0 marker at position 764 (0x2FC).
]]
audiowmark: error opening -: Error in WAV file. No 'data' chunk marker.
```
I tracked this down, the problem is that libsndfile will try to skip over the huge unknown "pad " chunk using psf_fseek. But if the input is a pipe, seeking is not supported. So this commit fixes the problem by reading over the chunk data using psf_fread if the input is a pipe.