### PR TITLE
Handle EAGAIN when reading files

### DIFF
--- a/src/file_io.c
+++ b/src/file_io.c
@@ -361,7 +361,7 @@ psf_fread (void *ptr, sf_count_t bytes, sf_count_t items, SF_PRIVATE *psf)
 		count = read (psf->file.filedes, ((char*) ptr) + total, (size_t) count) ;
 
 		if (count == -1)
-		{	if (errno == EINTR)
+		{	if (errno == EINTR || errno == EAGAIN)
 				continue ;
 
 			psf_log_syserr (psf, errno) ;


### PR DESCRIPTION
Apparently this can happen even when the file descriptor is in blocking mode, as seen in this strace:

```
176595 read(0,  <unfinished ...>
176595 <... read resumed>0x7ffdf39ace94, 2092) = -1 EAGAIN (Resource temporarily unavailable)
```

The case at hand happens with [elbestream](https://code.uplex.de/misc/elbestream), which has been written as intermediate relief for sound processing programs which fail stream processing on some inputs.

When stdin of the program using libsndfile is handed over to [vmsplice()](https://code.uplex.de/misc/elbestream/blob/e42437c85432ef042743e3004e7c52295e3ae35f/elbestream.c#L168) the `EAGAIN` is seen repeatedly, though not always.