### PR TITLE
Fix build errors on UWP platform with Visual Studio 2022

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -190,7 +190,7 @@ psf_log_printf (SF_PRIVATE *psf, const char *format, ...)
 						if (lead_char != '0' && left_align == SF_FALSE)
 							width_specifier -- ;
 
-						u = - ((unsigned) d) ;
+						u = - (int32_t) ((unsigned) d) ;
 						}
 					else
 					{	u = (unsigned) d ;
@@ -252,7 +252,7 @@ psf_log_printf (SF_PRIVATE *psf, const char *format, ...)
 						else
 						{	if (D < 0)
 							{	log_putchar (psf, '-') ;
-								U = -((uint64_t) D) ;
+								U = - (int64_t) ((uint64_t) D) ;
 								}
 							else
 							{	U = (uint64_t) D;


### PR DESCRIPTION
I ran into problems when updating the [Vcpkg](https://github.com/microsoft/vcpkg) port to 1.1.0, specifically the build for the [UWP platform](https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide) was completed with [warning C4146: "unary minus operator applied to unsigned type, result still unsigned"](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?f1url=%3FappId%3DDev16IDEF1%26l%3DRU-RU%26k%3Dk(C4146)%26rd%3Dtrue&view=msvc-170).

Although UWP is also partly Windows, but a lot of things are done differently there and from some point the warning was translated into an error.