### PR TITLE
Read more than 2^24 samples from FLAC file with non-power-of-two channels

### DIFF
--- a/src/flac.c
+++ b/src/flac.c
@@ -43,6 +43,15 @@
 
 #define ENC_BUFFER_SIZE 8192
 
+/*
+** READ_LOOP_MAX_LEN is the maximum 'len' that will be passed to
+** flac_read_loop().  This is somewhat arbitrary, but must be less
+** than (UINT_MAX - FLAC__MAX_CHANNELS * FLAC__MAX_BLOCK_SIZE) to
+** avoid overflows, and must also be a multiple of the number of
+** channels (which is between 1 and 8.)
+*/
+#define READ_LOOP_MAX_LEN (0x10000 * 3 * 5 * 7)
+
 typedef enum
 {	PFLAC_PCM_SHORT = 50,
 	PFLAC_PCM_INT = 51,
@@ -977,7 +986,7 @@ flac_read_flac2s (SF_PRIVATE *psf, short *ptr, sf_count_t len)
 
 	while (total < len)
 	{	pflac->ptr = ptr + total ;
-		readlen = (len - total > 0x1000000) ? 0x1000000 : (unsigned) (len - total) ;
+		readlen = (len - total > READ_LOOP_MAX_LEN) ? READ_LOOP_MAX_LEN : (unsigned) (len - total) ;
 		current = flac_read_loop (psf, readlen) ;
 		if (current == 0)
 			break ;
@@ -997,7 +1006,7 @@ flac_read_flac2i (SF_PRIVATE *psf, int *ptr, sf_count_t len)
 
 	while (total < len)
 	{	pflac->ptr = ptr + total ;
-		readlen = (len - total > 0x1000000) ? 0x1000000 : (unsigned) (len - total) ;
+		readlen = (len - total > READ_LOOP_MAX_LEN) ? READ_LOOP_MAX_LEN : (unsigned) (len - total) ;
 		current = flac_read_loop (psf, readlen) ;
 		if (current == 0)
 			break ;
@@ -1017,7 +1026,7 @@ flac_read_flac2f (SF_PRIVATE *psf, float *ptr, sf_count_t len)
 
 	while (total < len)
 	{	pflac->ptr = ptr + total ;
-		readlen = (len - total > 0x1000000) ? 0x1000000 : (unsigned) (len - total) ;
+		readlen = (len - total > READ_LOOP_MAX_LEN) ? READ_LOOP_MAX_LEN : (unsigned) (len - total) ;
 		current = flac_read_loop (psf, readlen) ;
 		if (current == 0)
 			break ;
@@ -1037,7 +1046,7 @@ flac_read_flac2d (SF_PRIVATE *psf, double *ptr, sf_count_t len)
 
 	while (total < len)
 	{	pflac->ptr = ptr + total ;
-		readlen = (len - total > 0x1000000) ? 0x1000000 : (unsigned) (len - total) ;
+		readlen = (len - total > READ_LOOP_MAX_LEN) ? READ_LOOP_MAX_LEN : (unsigned) (len - total) ;
 
 		current = flac_read_loop (psf, readlen) ;
 		if (current == 0)


### PR DESCRIPTION
As discussed in issue #431: when reading a FLAC file, the `sf_read_*` or `sf_readf_*` functions will fail if the total number of samples exceeds 0x1000000, and the number of channels is not a power of two.

This is because (e.g.) `flac_read_flac2s` will invoke `flac_read_loop` with a buffer size of at most 0x1000000, and `flac_read_loop` requires the size to be a multiple of the number of channels.

This logic was introduced with commit d81614ca9068959884a6db3b78b8892e76055956, which unfortunately does not have a very detailed commit message.  That commit does two things that appear unrelated:

(1) It ensures that `flac_buffer_copy` makes a private copy of the input data.

(2) It uses `unsigned` counters in `flac_read_loop` and elsewhere, in place of `sf_count_t`.

The first change is necessary because of how libFLAC works (you cannot continue accessing the data passed to `sf_flac_write_callback` after `sf_flac_write_callback` returns), and presumably this was the "valgrind error" in question.

The second change is not easy to explain, but one possible benefit is that `sf_count_t` might have been only 32 bits, and this logic permits reading more than 2^31 samples in that case.  (Which would only have made sense on truly crazy platforms like 64-bit Windows, but hey.)  Nowadays, as far as I can tell, `sf_count_t` is always at least 64 bits, so this should no longer be an issue.

At any rate: a simple fix for issue #431 is to change the internal size limit to a value that is divisible by every possible number of channels (1, 2, 3, 4, 5, 6, 7, or 8).

If you would like, I can also try to provide a patch to revert to the pre-d81614ca9068959884a6db3b78b8892e76055956 logic, though that's harder to test.
