### PR TITLE
Define SF_COUNT_MAX as INT64_MAX.

### DIFF
--- a/include/sndfile.h
+++ b/include/sndfile.h
@@ -367,7 +367,7 @@ typedef	struct sf_private_tag	SNDFILE ;
 
 typedef int64_t			sf_count_t ;
 #ifndef SF_COUNT_MAX
-#define SF_COUNT_MAX		0x7FFFFFFFFFFFFFFFLL
+#define SF_COUNT_MAX	INT64_MAX
 #endif
 
 


### PR DESCRIPTION
INT64_MAX instead of 0x7FFFFFFFFFFFFFFFLL avoids type discrepancy between int64_t and LL (long long) suffix when int64_t is not long long.