### PR TITLE
sndfile-play: use sndio when available

### DIFF
--- a/programs/sndfile-play.c
+++ b/programs/sndfile-play.c
@@ -47,7 +47,10 @@
 
 #include "common.h"
 
-#if HAVE_ALSA_ASOUNDLIB_H
+#if HAVE_SNDIO_H
+	#include <sndio.h>
+
+#elif HAVE_ALSA_ASOUNDLIB_H
 	#define ALSA_PCM_NEW_HW_PARAMS_API
 	#define ALSA_PCM_NEW_SW_PARAMS_API
 	#include <alsa/asoundlib.h>
@@ -60,9 +63,6 @@
 	#include 	<fcntl.h>
 	#include 	<sys/ioctl.h>
 	#include 	<sys/soundcard.h>
-
-#elif HAVE_SNDIO_H
-	#include <sndio.h>
 
 #elif (defined (sun) && defined (unix)) || defined(__NetBSD__)
 	#include <fcntl.h>


### PR DESCRIPTION
libsndio is also available on Linux. Use it when found instead of alsa.

Signed-off-by: Rosen Penev <rosenp@gmail.com>