### PR TITLE
mpeg_decode: Fix bug where final bytes from mpg123_read() where ignored.

### DIFF
--- a/src/mpeg_decode.c
+++ b/src/mpeg_decode.c
@@ -91,11 +91,8 @@ mpeg_dec_decode (SF_PRIVATE *psf, float *ptr, sf_count_t len)
 
 	error = mpg123_read (pmp3d->pmh, (unsigned char *) ptr, len * sizeof (float), &done) ;
 
-	if (error == MPG123_OK)
+	if (error == MPG123_OK || error == MPG123_DONE)
 		return done / sizeof (float) ;
-
-	if (error == MPG123_DONE)
-		return 0 ;
 
 	if (error == MPG123_NEW_FORMAT)
 	{	psf->error = SFE_MALFORMED_FILE ;


### PR DESCRIPTION
Resolve #880 

Most every read api I've ever worked with return no error and positive byte counts, or zero bytes and an end or error condition. When the end of stream is reached, the last read will contain the last bytes, and the next call to read returns an error indicating that end has been reached.

But not mpg123, no, when reaching the last bytes, it returns the last bytes AND sets the error condition to done.

Assumptions make and ass of you an mumptions.