### PR TITLE
Let wav parsing recover from invalid LIST chunks, fixing #374

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -375,7 +375,7 @@ psf_log_printf (SF_PRIVATE *psf, const char *format, ...)
 					strptr = istr ;
 					while (*strptr)
 					{	c = *strptr++ ;
-						log_putchar (psf, c) ;
+						log_putchar (psf, psf_isprint (c) ? c : '.') ;
 						} ;
 					break ;
 

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -1026,7 +1026,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 			case ITRK_MARKER :
 					bytesread += psf_binheader_readf (psf, "4", &chunk_size) ;
 					chunk_size += (chunk_size & 1) ;
-					if (chunk_size >= SIGNED_SIZEOF (buffer) || chunk_size >= chunk_length)
+					if (chunk_size >= SIGNED_SIZEOF (buffer) || bytesread + chunk_size > chunk_length)
 					{	psf_log_printf (psf, "  *** %M : %u (too big)\n", chunk, chunk_size) ;
 						goto cleanup_subchunk_parse ;
 						} ;
@@ -1042,7 +1042,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 						bytesread += psf_binheader_readf (psf, "44", &chunk_size, &mark_id) ;
 						chunk_size -= 4 ;
 						chunk_size += (chunk_size & 1) ;
-						if (chunk_size < 1 || chunk_size >= SIGNED_SIZEOF (buffer) || chunk_size >= chunk_length)
+						if (chunk_size < 1 || chunk_size >= SIGNED_SIZEOF (buffer) || bytesread + chunk_size > chunk_length)
 						{	psf_log_printf (psf, "  *** %M : %u (too big)\n", chunk, chunk_size) ;
 							goto cleanup_subchunk_parse ;
 							} ;
@@ -1073,7 +1073,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 			case note_MARKER :
 					bytesread += psf_binheader_readf (psf, "4", &chunk_size) ;
 					chunk_size += (chunk_size & 1) ;
-					if (chunk_size >= SIGNED_SIZEOF (buffer) || chunk_size >= chunk_length)
+					if (chunk_size >= SIGNED_SIZEOF (buffer) || bytesread + chunk_size > chunk_length)
 					{	psf_log_printf (psf, "  *** %M : %u (too big)\n", chunk, chunk_size) ;
 						goto cleanup_subchunk_parse ;
 						} ;

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -1003,10 +1003,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 					**	the rest of the chunk is garbage.
 					*/
 					psf_log_printf (psf, "    *** Found weird-ass zero marker. Jumping to end of chunk.\n") ;
-					if (bytesread < chunk_length)
-						bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread) ;
-					psf_log_printf (psf, "    *** Offset is now : 0x%X\n", psf_fseek (psf, 0, SEEK_CUR)) ;
-					return 0 ;
+					goto cleanup_subchunk_parse ;
 
 			default :
 					break ;
@@ -1089,8 +1086,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 					chunk_size += (chunk_size & 1) ;
 					if (bytesread + chunk_size > chunk_length)
 					{	psf_log_printf (psf, "  *** %M : %u (too big)\n", chunk, chunk_size) ;
-						bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread) ;
-						continue ;
+						goto cleanup_subchunk_parse ;
 						}
 					else
 					{	psf_log_printf (psf, "    %M : %u\n", chunk, chunk_size) ;

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -1089,7 +1089,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 					chunk_size += (chunk_size & 1) ;
 					psf_log_printf (psf, "    *** %M : %u\n", chunk, chunk_size) ;
 					if (bytesread + chunk_size > chunk_length)
-					{	bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread + 4) ;
+					{	bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread) ;
 						continue ;
 						}
 					else

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -1096,9 +1096,6 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 					{	psf_log_printf (psf, "    %M : %u\n", chunk, chunk_size) ;
 						bytesread += psf_binheader_readf (psf, "j", chunk_size) ;
 						} ;
-
-					if (chunk_size >= chunk_length)
-						return 0 ;
 					break ;
 			} ;
 

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -981,7 +981,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 		switch (chunk)
 		{	case adtl_MARKER :
 			case INFO_MARKER :
-					/* These markers don't contain anything, not even a chunk lebgth. */
+					/* These markers don't contain anything, not even a chunk length. */
 					psf_log_printf (psf, "  %M\n", chunk) ;
 					continue ;
 

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -1087,13 +1087,15 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 			default :
 					bytesread += psf_binheader_readf (psf, "4", &chunk_size) ;
 					chunk_size += (chunk_size & 1) ;
-					psf_log_printf (psf, "    *** %M : %u\n", chunk, chunk_size) ;
 					if (bytesread + chunk_size > chunk_length)
-					{	bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread) ;
+					{	psf_log_printf (psf, "  *** %M : %u (too big)\n", chunk, chunk_size) ;
+						bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread) ;
 						continue ;
 						}
 					else
+					{	psf_log_printf (psf, "    %M : %u\n", chunk, chunk_size) ;
 						bytesread += psf_binheader_readf (psf, "j", chunk_size) ;
+						} ;
 
 					if (chunk_size >= chunk_length)
 						return 0 ;

--- a/tests/cpp_test.cc
+++ b/tests/cpp_test.cc
@@ -106,7 +106,7 @@ check_title (const SndfileHandle & file, const char * filename)
 	title = file.getString (SF_STR_TITLE) ;
 
 	if (title == NULL)
-	{	printf ("\n\n%s %d : Error : No title.\n\n", __func__, __LINE__) ;
+	{	printf ("\n\n%s %d : Error : No title for %s.\n\n", __func__, __LINE__, filename) ;
 		exit (1) ;
 		} ;
 

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -199,17 +199,15 @@ wav_list_recover_test (const char * filename)
 	memset (&sfinfo, 0, sizeof (sfinfo)) ;
 	sndfile = sf_open (filename, SFM_READ, &sfinfo) ;
 
-	if (sndfile)
-	{	printf ("\n\nLine %d : expected failure - issue 374 reports no recovery from bogus LIST content.\n", __LINE__) ;
+	if (!sndfile)
+	{	printf ("\n\nLine %d : expected recovery from bogus LIST content.\n", __LINE__) ;
 		exit (1) ;
 		} ;
 
-	/*
 	if (sfinfo.frames != 2)
 	{	printf ("\n\nLine %d : Should have read data chunk with 2 stereo frames, got %ld.\n\n", __LINE__, (long)sfinfo.frames) ;
 		exit (1) ;
 		} ;
-	*/
 
 	unlink (filename) ;
 	puts ("ok") ;


### PR DESCRIPTION
This triggered other minor fixes and cleanup. See the individual commits.