### PR TITLE
wavlike: Find a use for unused bytes total

### DIFF
--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -902,6 +902,9 @@ wavlike_read_cart_chunk (SF_PRIVATE *psf, uint32_t chunksize)
 		bytes += psf_binheader_readf (psf, "b", c->tag_text, make_size_t (c->tag_text_size)) ;
 		} ;
 
+	if (bytes < chunksize)
+		psf_log_printf (psf, "  %d trailing bytes in cart chunk.\n", chunksize - bytes) ;
+
 	return 0 ;
 } /* wavlike_read_cart_chunk */
 


### PR DESCRIPTION
Compile upgrades have found an existing set-but-unused variable in `wavlike_read_cart_chunk()`

Rather than remove the unread `bytes` variable (which possibly points to another bug, that read's don't appear to be bounded), use the bytes tally for a debug message about padding bytes.