### PR TITLE
version 1.2.0, not 1.1.0

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,3 @@
-This is libsndfile, 1.1.0
-
 libsndfile is a library of C routines for reading and writing
 files containing sampled audio data.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,6 +144,8 @@ Here is the release history for libsndfile:
   reported by OSS-Fuzz. More SSE2-optimized functions for x86 and amd64.
 * Version 1.1.0 (March 27 2022) Minor release, backward compatible with previous
   releases. Added long-awaited MP3 support. Numerous improvements and bugfixes.
+* Version 1.2.0 (December 25 2022) Various bugfixes,
+  removed artificial samplerate limit
 
 ## Similar or Related Projects
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "libsndfile",
     "description": "A library for reading and writing audio files",
-    "version-semver": "1.1.0",
+    "version-semver": "1.2.0",
     "default-features": [
         "external-libs",
         "mpeg"


### PR DESCRIPTION
The 1.2.0 release is not mentioned in the history of releases,
and 1.1.0 seems to have been left in a few places.
Why do we have both README and README.md?