### PR TITLE
Fix static downstream projects build using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,7 +846,24 @@ if (ENABLE_PACKAGE_CONFIG)
 			${CMAKE_CURRENT_BINARY_DIR}/SndFileConfigVersion.cmake
 		DESTINATION	${CMAKE_INSTALL_PACKAGEDIR}
 		)
-
+        if (SndFile_WITH_EXTERNAL_LIBS AND NOT BUILD_SHARED_LIBS)
+            install(FILES
+                    ${PROJECT_SOURCE_DIR}/cmake/FindFLAC.cmake
+                    ${PROJECT_SOURCE_DIR}/cmake/FindOgg.cmake
+                    ${PROJECT_SOURCE_DIR}/cmake/FindOpus.cmake
+                    ${PROJECT_SOURCE_DIR}/cmake/FindSndio.cmake
+                    ${PROJECT_SOURCE_DIR}/cmake/FindSpeex.cmake
+                    ${PROJECT_SOURCE_DIR}/cmake/FindVorbis.cmake
+                    DESTINATION ${CMAKE_INSTALL_PACKAGEDIR}
+                    )
+        endif()
+        if (SndFile_WITH_MPEG AND NOT BUILD_SHARED_LIBS)
+            install(FILES
+                    ${PROJECT_SOURCE_DIR}/cmake/FindMPG123.cmake
+                    ${PROJECT_SOURCE_DIR}/cmake/Findmp3lame.cmake
+                    DESTINATION ${CMAKE_INSTALL_PACKAGEDIR}
+                    )
+        endif()
 else ()
 
 	install (TARGETS sndfile ${sdnfile_PROGRAMS}

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ cmake_files = cmake/ClipMode.cmake cmake/FindFLAC.cmake \
 	cmake/TestLargeFiles.cmake cmake/TestInline.c.in \
 	cmake/FindOpus.cmake cmake/SndFileConfig.cmake.in \
 	cmake/CheckCPUArch.cmake cmake/CheckCPUArch.c.in \
-	cmake/Findmp3lame.cmake cmake/FindMpg123.cmake \
+	cmake/Findmp3lame.cmake cmake/FindMPG123.cmake \
 	cmake/SetupABIVersions.cmake
 
 pkgconfig_DATA = sndfile.pc

--- a/cmake/FindMPG123.cmake
+++ b/cmake/FindMPG123.cmake
@@ -3,7 +3,7 @@
 #
 #  MPG123_INCLUDE_DIRS - where to find mpg123.h, etc.
 #  MPG123_LIBRARIES    - List of libraries when using mpg123.
-#  MPG123_FOUND        - True if Mpg123 found.
+#  MPG123_FOUND        - True if MPG123 found.
 
 if (MPG123_INCLUDE_DIR)
     # Already in cache, be silent
@@ -40,7 +40,7 @@ find_library (MPG123_LIBRARY
 # Handle the QUIETLY and REQUIRED arguments and set MPG123_FOUND
 # to TRUE if all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args (Mpg123
+find_package_handle_standard_args (MPG123
 	REQUIRED_VARS
 		MPG123_LIBRARY
 		MPG123_INCLUDE_DIR

--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -50,7 +50,7 @@ else ()
 endif ()
 
 find_package (mp3lame)
-find_package (Mpg123 1.25.10)
+find_package (MPG123 1.25.10)
 if (TARGET mp3lame::mp3lame AND (TARGET MPG123::libmpg123))
 	set (HAVE_MPEG_LIBS 1)
 else ()

--- a/cmake/SndFileConfig.cmake.in
+++ b/cmake/SndFileConfig.cmake.in
@@ -5,19 +5,24 @@ set(SndFile_VERSION_PATCH @PROJECT_VERSION_PATCH@)
 
 set (SndFile_WITH_EXTERNAL_LIBS @SndFile_WITH_EXTERNAL_LIBS@)
 set (SndFile_WITH_MPEG @SndFile_WITH_MPEG@)
+set (SndFile_STATIC NOT @BUILD_SHARED_LIBS@)
 
 @PACKAGE_INIT@
 
 include (CMakeFindDependencyMacro)
 
-if (SndFile_WITH_EXTERNAL_LIBS AND NOT @BUILD_SHARED_LIBS@)
+if ((SndFile_WITH_EXTERNAL_LIBS OR SndFile_WITH_MPEG) AND SndFile_STATIC)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+endif()
+
+if (SndFile_WITH_EXTERNAL_LIBS AND SndFile_STATIC)
 	find_dependency (Ogg 1.3)
 	find_dependency (Vorbis)
 	find_dependency (FLAC)
 	find_dependency (Opus)
 endif ()
 
-if (SndFile_WITH_MPEG AND NOT @BUILD_SHARED_LIBS@)
+if (SndFile_WITH_MPEG AND SndFile_STATIC)
 	find_dependency (mp3lame)
 	find_dependency (MPG123)
 endif ()


### PR DESCRIPTION
* Installs the cmake/Find*.cmake modules when installing a static lib
* Adjusts SndFileConfig to search also the installed cmake modules
* Renames FindMpg123.cmake to FindMPG123.cmake to avoid problems in case sensitive filesystems, like in Linux

Closes #916 