### PR TITLE
CMake: Explicitly link against Ogg::ogg.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ target_include_directories (sndfile
 target_link_libraries (sndfile
 	PRIVATE
 		$<$<BOOL:${LIBM_REQUIRED}>:m>
+		$<$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>:Ogg::ogg>
 		$<$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>:Vorbis::vorbisenc>
 		$<$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>:FLAC::FLAC>
 		$<$<AND:$<BOOL:${ENABLE_EXPERIMENTAL}>,$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>,$<BOOL:${HAVE_SPEEX}>>:Speex::Speex>


### PR DESCRIPTION
This PR adds `Ogg::ogg` to the linked libraries since it is explicitly used in `src/ogg*.c` source files.

Previous to this PR, `Ogg::ogg` was provided transitively by Vorbis and FLAC, and as such not added to the `INTERFACE_LINK_LIBRARIES` of the exported target in static builds.

This problem can be reproduced the following way
- Build a static version of libsndfile with Xiph codecs
- Use a shared version of libvorbis and libFLAC
- Have a custom Find modules for Vorbis and FLAC that rely on pkg-config, or that do not search for transitive dependencies and relies on the user manually passing link flags when needed (e.g. [SDL2_mixer](https://github.com/libsdl-org/SDL_mixer/blob/SDL2/cmake/FindFLAC.cmake)).

Since both Vorbis and FLAC are shared, they have no link-time dependency, but sndfile fails linking with:
```
libsndfile.a(ogg.c.o): undefined reference to symbol 'ogg_stream_reset'
```