### PR TITLE
fix #888, change diffrence of 'ret', 'offset' form Xiph.org's Opusfile: opusfile-0.12/src/opusfile.c

### DIFF
--- a/src/ogg.c
+++ b/src/ogg.c
@@ -424,12 +424,13 @@ ogg_sync_last_page_before (SF_PRIVATE *psf, OGG_PRIVATE *odata, uint64_t *gp_out
 		left_link = 0 ;
 		while (position < end)
 		{	ret = ogg_sync_next_page (psf, &odata->opage, end - position, &position) ;
-			if (ret <= 0)
+			if (ret < 0)
 				return -1 ;
+			else if (ret == 0) break ;
 			if (ogg_page_serialno (&odata->opage) == serialno)
 			{	uint64_t page_gp = ogg_page_granulepos (&odata->opage) ;
 				if (page_gp != (uint64_t) -1)
-				{	offset = position ;
+				{	offset = ret ;
 					gp = page_gp ;
 					}
 				}

--- a/src/ogg.c
+++ b/src/ogg.c
@@ -430,7 +430,7 @@ ogg_sync_last_page_before (SF_PRIVATE *psf, OGG_PRIVATE *odata, uint64_t *gp_out
 			if (ogg_page_serialno (&odata->opage) == serialno)
 			{	uint64_t page_gp = ogg_page_granulepos (&odata->opage) ;
 				if (page_gp != (uint64_t) -1)
-				{	offset = ret ;
+				{	offset = position ;
 					gp = page_gp ;
 					}
 				}


### PR DESCRIPTION
I compared the relative part of `ogg.c` with Xiph.org's opusfile-0.12/src/opusfile.c, and found there is a little difference between them. changing it makes #888 succeed.