### PR TITLE
Avoid redefining ssize_t when building with autotools

### DIFF
--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -148,6 +148,10 @@
 /* Define to 1 if the system has the type `ssize_t'. */
 #cmakedefine01 HAVE_SSIZE_T
 
+#if (HAVE_SSIZE_T == 0)
+#define ssize_t intptr_t
+#endif
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine01 HAVE_STDINT_H
 

--- a/src/sfconfig.h
+++ b/src/sfconfig.h
@@ -128,12 +128,4 @@
 #define USE_SSE2
 #endif
 
-#ifndef HAVE_SSIZE_T
-#define HAVE_SSIZE_T 0
-#endif
-
-#if (HAVE_SSIZE_T == 0)
-#define ssize_t intptr_t
-#endif
-
 #endif


### PR DESCRIPTION
`HAVE_SSIZE_T` isn't defined when building with autotools, which results in `ssize_t` being defined and interfering with system headers when the real `ssize_t` is defined. Since autotools provides its own replacement, the relevant code has been moved to `config.h.cmake`.