### PR TITLE
Ensure the tribyte structure is properly packed

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -92,7 +92,7 @@
 #define		SF_MIN(a, b)	((a) < (b) ? (a) : (b))
 
 
-#define		COMPILE_TIME_ASSERT(e)	(sizeof (struct { int : - !! (e) ; }))
+#define		COMPILE_TIME_ASSERT(e)	(sizeof (struct { int : - ! (e) ; }))
 
 
 #define		SF_MAX_CHANNELS		1024

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -28,11 +28,17 @@
 ** type and use SIZEOF_TRIBYTE instead of (tribyte).
 */
 
+#pragma pack(1)
+
 typedef	struct tribyte
 {	uint8_t bytes [3] ;
 	} tribyte ;
 
+#pragma pack()
+
 #define	SIZEOF_TRIBYTE	3
+
+static const int tribyte_assert = COMPILE_TIME_ASSERT(sizeof(tribyte) == SIZEOF_TRIBYTE);
 
 static sf_count_t	pcm_read_sc2s	(SF_PRIVATE *psf, short *ptr, sf_count_t len) ;
 static sf_count_t	pcm_read_uc2s	(SF_PRIVATE *psf, short *ptr, sf_count_t len) ;


### PR DESCRIPTION
This is needed when building for RISC OS (and possibly older ARM Linux toolchains), where structures are padded to a multiple of 4 bytes by default.