### PR TITLE
AIFF fixes

### DIFF
--- a/src/aiff.c
+++ b/src/aiff.c
@@ -1060,7 +1060,7 @@ aiff_read_comm_chunk (SF_PRIVATE *psf, COMM_CHUNK *comm_fmt)
 		psf_log_printf (psf, "  Sample Size : %d\n", comm_fmt->sampleSize) ;
 
 
-	if (psf->sf.channels != comm_fmt->numChannels && psf->peak_info)
+	if ((psf->sf.channels != comm_fmt->numChannels) && psf->peak_info)
 	{	psf_log_printf (psf, "  *** channel count changed, discarding existing PEAK chunk\n") ;
 		free (psf->peak_info) ;
 		psf->peak_info = NULL ;

--- a/src/aiff.c
+++ b/src/aiff.c
@@ -1059,6 +1059,13 @@ aiff_read_comm_chunk (SF_PRIVATE *psf, COMM_CHUNK *comm_fmt)
 	else
 		psf_log_printf (psf, "  Sample Size : %d\n", comm_fmt->sampleSize) ;
 
+
+	if (psf->sf.channels != comm_fmt->numChannels && psf->peak_info)
+	{	psf_log_printf (psf, "  *** channel count changed, discarding existing PEAK chunk\n") ;
+		free (psf->peak_info) ;
+		psf->peak_info = NULL ;
+		} ;
+
 	subformat = s_bitwidth_to_subformat (comm_fmt->sampleSize) ;
 
 	psf->sf.samplerate = samplerate ;

--- a/src/common.c
+++ b/src/common.c
@@ -252,10 +252,10 @@ psf_log_printf (SF_PRIVATE *psf, const char *format, ...)
 						else
 						{	if (D < 0)
 							{	log_putchar (psf, '-') ;
-								U = -((uint64_t) D) ;
+								U = - ((uint64_t) D) ;
 								}
 							else
-							{	U = (uint64_t) D;
+							{	U = (uint64_t) D ;
 								}
 							}
 


### PR DESCRIPTION
Two fixes related to the AIFF container.

## Drop PEAK info if channel count changes

Chunks inside of an AIFF file can come in any order. There are two places chunks which can specify channel count, the containing FORM chunk and the COMM chunk. The PEAK chunk doesn't specify a size, and is proportional to the known channel count. If the COMM chunk occurs after the PEAK chunk, and has a different channel count, the PEAK chunk should be discarded. Firstly because there is no reasonable behaviour on how to adapt the peak info, and secondly because the memory allocation for the peak info is no longer the correct size.

## Ignore data padding when re-writing header

AIFF files can have an arbitrary gap between the end of the header data and the start of the audio data. (This is referenced by the AIFF spec as to aid accelerated filesystem block aligned writes.) These extra pad bytes, if present, are not read by libsndfile. When rewriting the AIFF header in the case of a file opened for RDWR, previously entire range of [0, psf->dataoffset] was used as the header data. As `dataoffset` pointed to the first byte of audio data, it included these padding bytes.

Firstly, this is a waste of effort, as the pad bytes should be ignored and unchanged.

Secondly, as the binheader buffer mechanism is used to read the header, and the pad bytes were not read when initially parsing the header, the additional read of the pad bytes can potentially overflow the existing memory allocation of the binheader buffer. A maliciously crafted file could do this easily.

Instead, calculate the actual header size from the saved SSND chunk offset and fixed size of the SSND chunk before the padding bytes. Additionally, this PR adds some sanity checks before reusing the binheader buffer.

## Additional Changes

- Fix a style error in `common.c`
- ~~Move the maximum binheader allocation size to a `#define`~~
- ~~Allow for allocation up to the binheader maximum size.~~

Binheader changes stripped due to fuzzing issues for now.