### PR TITLE
mpeg: fix reading of mpeg files that lack an INFO header

### DIFF
--- a/src/mpeg_decode.c
+++ b/src/mpeg_decode.c
@@ -203,7 +203,7 @@ mpeg_dec_seek (SF_PRIVATE *psf, int mode, sf_count_t count)
 } /* mpeg_dec_seek */
 
 static int
-mpeg_dec_fill_sfinfo (mpg123_handle *mh, SF_INFO *info)
+mpeg_dec_fill_sfinfo (SF_PRIVATE* psf, mpg123_handle *mh, SF_INFO *info)
 {	int error ;
 	int channels ;
 	int encoding ;
@@ -218,6 +218,12 @@ mpeg_dec_fill_sfinfo (mpg123_handle *mh, SF_INFO *info)
 	info->channels = channels ;
 
 	length = mpg123_length (mh) ;
+	if (length <= 0 && !psf->is_pipe)
+	{	if ((error = mpg123_scan(mh)) != MPG123_OK)
+			return error ;
+		length = mpg123_length(mh) ;
+		}
+
 	if (length >= 0)
 	{	info->frames = length ;
 		info->seekable = SF_TRUE ;
@@ -577,7 +583,7 @@ mpeg_decoder_init (SF_PRIVATE *psf)
 		return SFE_BAD_FILE ;
 		} ;
 
-	if (mpeg_dec_fill_sfinfo (pmp3d->pmh, &psf->sf) != MPG123_OK)
+	if (mpeg_dec_fill_sfinfo (psf, pmp3d->pmh, &psf->sf) != MPG123_OK)
 	{	psf_log_printf (psf, "Cannot get MPEG decoder configuration: %s\n", mpg123_plain_strerror (error)) ;
 		return SFE_BAD_FILE ;
 		} ;


### PR DESCRIPTION
I encountered some funky MP3 files that are not using the ID3 container, and cannot be successfully read by sndfile. The library correctly identifies them as mpeg files based on the frame header, but it thinks they have no data because mpg123_length returns 0. According to the [mpg123 docs](https://www.mpg123.de/api/group__mpg123__status.shtml#ga7a97295f5dd82795489d9ed8ee544805), length relies on either an info header at the start of the file or a previous call to mpg123_scan.

Not sure if this is the most optimal solution, but it works. Let me know if my commit message is inaccurate, I'm not an audio programmer :) 