### PR TITLE
docs: fix various typos

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,7 @@ documented) [here](command.md).**
 | [sf_writef_short, sf_writef_int, sf_writef_float, sf_writef_double](#writef)                                | File frames write functions.                   |
 | [sf_read_raw, sf_write_raw](#raw)                                                                           | Raw read/write functions.                      |
 | [sf_get_string, sf_set_string](#string)                                                                     | Functions for reading and writing string data. |
-| [sf_version_string](#version_string)                                                                        | Retrive library version string.                |
+| [sf_version_string](#version_string)                                                                        | Retrieve library version string.                |
 | [sf_current_byterate](#current_byterate)                                                                    | Retrieve current byterate.                     |
 | [sf_set_chunk, sf_get_chunk_iterator, sf_next_chunk_iterator, sf_get_chunk_size, sf_get_chunk_data](#chunk) | RIFF chunks API.                               |
 
@@ -262,7 +262,7 @@ typedef sf_count_t  (*sf_vio_tell)        (void *user_data) ;
 typedef sf_count_t  (*sf_vio_get_filelen) (void *user_data) ;
 ```
 
-The virtual file contex must return the length of the virtual file in bytes.
+The virtual file context must return the length of the virtual file in bytes.
 
 #### sf_vio_seek
 
@@ -347,7 +347,7 @@ Note that the frames offset can be negative and in fact should be when SEEK_END
 is used for the whence parameter.
 
 sf_seek will return the offset in (multichannel) frames from the start of the
-audio data or -1 if an error occured (ie an attempt is made to seek beyond the
+audio data or -1 if an error occurred (ie an attempt is made to seek beyond the
 start or end of the file).
 
 ## Error Reporting Functions {#error}
@@ -557,7 +557,7 @@ others like WAV and AIFF officially only support ASCII. Writing utf-8 strings to
 WAV and AIF files with libsndfile will work when read back with libsndfile, but
 may not work with other programs.
 
-The suggested method of dealing with tags retrived using sf_get_string() is to
+The suggested method of dealing with tags retrieved using sf_get_string() is to
 assume they are utf-8. Similarly if you have a string in some exotic format like
 utf-16, it should be encoded to utf-8 before being written using libsndfile.
 
@@ -733,7 +733,7 @@ interface.
 
 ## Note 2
 
-Reading a file containg floating point data (allowable with WAV, AIFF, AU and
+Reading a file containing floating point data (allowable with WAV, AIFF, AU and
 other file formats) using integer read methods (sf_read_short() or
 sf_read_int()) can produce unexpected results. For instance the data in the file
 may have a maximum absolute value &lt; 1.0 which would mean that all sample

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -14,7 +14,7 @@ Bugs I want to fix include any of the following problems (and probably others):
 
 - Compilation problems on new platforms.
 - Errors being detected during the `make check` process.
-- Segmentation faults occuring inside libsndfile.
+- Segmentation faults occurring inside libsndfile.
 - libsndfile hanging when opening a file.
 - Supported sound file types being incorrectly read or written.
 - Omissions, errors or spelling mistakes in the documentation.
@@ -24,7 +24,7 @@ When submitting a bug report you must include:
 - Your system (CPU and memory size should be enough).
 - The operating system you are using.
 - Whether you are using a package provided by your distribution or you compiled
-  it youself.
+  it yourself.
 - If you compiled it yourself, the compiler you are using. (Also make sure to
   run `make check`.)
 - A description of the problem.

--- a/docs/command.md
+++ b/docs/command.md
@@ -1034,7 +1034,7 @@ sf_command (sndfile, SFC_FILE_TRUNCATE, &frames, sizeof (frames)) ;
 
 ### Return value
 
-Zero on sucess, non-zero otherwise.
+Zero on success, non-zero otherwise.
 
 ## SFC_SET_RAW_START_OFFSET
 
@@ -1228,7 +1228,7 @@ file format does not support ambisonic encoding.
 
 Set the Variable Bit Rate encoding quality. The encoding quality value
 should be between 0.0 (lowest quality) and 1.0 (highest quality).
-Currenly this command is only implemented for FLAC and Ogg/Vorbis files.
+Currently this command is only implemented for FLAC and Ogg/Vorbis files.
 It has no effect on un-compressed file formats.
 
 ### Parameters
@@ -1301,7 +1301,7 @@ datasize
 ## SFC_SET_COMPRESSION_LEVEL
 
 Set the compression level. The compression level should be between 0.0 (minimum
-compression level) and 1.0 (highest compression level). Currenly this command is
+compression level) and 1.0 (highest compression level). Currently this command is
 only implemented for FLAC and Ogg/Vorbis files. It has no effect on
 uncompressed file formats.
 
@@ -1604,7 +1604,7 @@ typedef struct
                               /* a full bar of 7/8 is 7 beats */
 
     float    bpm ;            /* suggestion, as it can be calculated using other fields:*/
-                              /* file's lenght, file's sampleRate and our time_sig_den*/
+                              /* file's length, file's sampleRate and our time_sig_den*/
                               /* -> bpms are always the amount of _quarter notes_ per minute */
 
     int    root_key ;         /* MIDI note, or -1 for None */
@@ -1627,7 +1627,7 @@ otherwise.
 ## SFC_GET_INSTRUMENT
 
 Retrieve instrument information from file including MIDI base note, keyboard
-mapping and looping informations(start/stop and mode).
+mapping and looping information (start/stop and mode).
 
 ### Parameters
 
@@ -1829,7 +1829,7 @@ sf_command (sndfile, SFC_SET_CUE, &cues, sizeof (cues)) ;
 
 Enable auto downgrade from RF64 to WAV.
 
-The EBU recomendation is that when writing RF64 files and the resulting file is
+The EBU recommendation is that when writing RF64 files and the resulting file is
 less than 4Gig in size, it should be downgraded to a WAV file (WAV files have a
 maximum size of 4Gig). libsndfile doesn't follow the EBU recommendations
 exactly, mainly because the test suite needs to be able test reading/writing

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@ The main repository can be found on Github:
 
 <https://github.com/libsndfile/libsndfile/>
 
-and includes [instuctions](https://github.com/libsndfile/libsndfile/blob/master/README.md)
+and includes [instructions](https://github.com/libsndfile/libsndfile/blob/master/README.md)
 on how to build libsndfile from the Git repo.
 
 If you are interested in how to add a new format to a libsndfile, you may find

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ Here is the release history for libsndfile:
 * Version 1.0.6 (Feb 08 2004) Large file fix for Linux/Solaris, new
   functionality   and Win32 improvements.
 * Version 1.0.7 (Feb 24 2004) Fix build problems on MacOS X and fix ia64/MIPS
-  etc clip mode detction.
+  etc clip mode detection.
 * Version 1.0.8 (Mar 14 2004) Minor bug fixes.
 * Version 1.0.9 (Mar 30 2004) Add AVR format. Improve handling of some WAV
   files.
@@ -112,7 +112,7 @@ Here is the release history for libsndfile:
   enhancements and bug fixes.
 * Version 1.0.17 (Aug 31 2006) Add C++ wrapper sndfile.hh. Minor bug fixes and
   cleanups.
-* Version 1.0.18 (Feb 07 2009) Add Ogg/Vorbis suppport, remove captive
+* Version 1.0.18 (Feb 07 2009) Add Ogg/Vorbis support, remove captive
   libraries, many new features and bug fixes. Generate Win32 and Win64
   pre-compiled binaries.
 * Version 1.0.19 (Mar 02 2009) Fix for CVE-2009-0186. Huge number of minor fixes

--- a/docs/linux_games_programming.txt
+++ b/docs/linux_games_programming.txt
@@ -175,7 +175,7 @@ which can be directly translated to:
 
 and the same for pcmbitwitdhs of 24 and 32. For pcmbitwidth of 8
 you need to know that WAV files use SF_FORMAT_PCM_U8 and AIFF
-files use SF_FORMAT_PCM_S8. Thats all there is to it.
+files use SF_FORMAT_PCM_S8. That's all there is to it.
 
 Erik
 -- 

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -12,7 +12,7 @@ There are three mailing lists for libsndfile:
 
  - **libsndfile-announce@mega-nerd.com**  
   [Subscribe](mailto:libsndfile-announce-request@mega-nerd.com?subject=subscribe)  
-  A list which will announce each new release of libsndfile. Noone can
+  A list which will announce each new release of libsndfile. No one can
   post to this list except the author.  
 - **libsndfile-devel@mega-nerd.com**  
   [Subscribe](mailto:libsndfile-devel-request@mega-nerd.com?subject=subscribe)  


### PR DESCRIPTION
Found via `codespell -q 3 -S ./NEWS.OLD -L caf,chek,dout,levl,merchantibility,nd,sav,writen`