### PR TITLE
MSVC: Fix building with SSE and ARM64EC

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -43,7 +43,11 @@
 #include <math.h>
 
 #ifdef USE_SSE2
-#include <immintrin.h>
+#	ifdef _MSC_VER
+#		include <intrin.h>
+#	else
+#		include <immintrin.h>
+#	endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Libsndfile currently directly includes `immintrin.h`, which does not work when compiling for ARM64EC with Visual Studio:
```
MSBuild version 17.7.0+5785ed5c2 for .NET Framework
  1>Checking Build System
  Building Custom Rule C:/.conan/456ac1/1/src/CMakeLists.txt
  common.c
  file_io.c
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.37.32820\include\immintrin.h(19,1): fatal  error C1189: #error:  this header should only be included through <intrin.h> (compiling source file C:\.conan\456ac1\1\src\src\common.c) [C:\.conan\456ac1\1\build\sndfile.vcxproj]
```
