### PR TITLE
Disable autogen make rules if autogen cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Disable autogen rules when autogen cannot be found
+
 ## [1.2.2] - 2023-08-13
 
 ### Fixed

--- a/Makefile.am
+++ b/Makefile.am
@@ -403,6 +403,7 @@ tests_scale_clip_test_LDADD = src/libsndfile.la
 # Yes, this sucks, but GNU make patterns aren't portable,
 # see also https://github.com/libsndfile/libsndfile/issues/369
 
+if HAVE_AUTOGEN
 SUFFIXES = .tpl .def
 
 .tpl.def:
@@ -424,6 +425,7 @@ tests/utils.h : tests/utils.c
 	  rm -f tests/utils.c && \
 	  $(MAKE) $(AM_MAKEFLAGS) tests/utils.c; \
 	fi
+endif
 
 ########
 # man/ #

--- a/configure.ac
+++ b/configure.ac
@@ -532,10 +532,7 @@ AS_IF([test "x$ac_cv_sizeof_double" != "x8"], [
 		AC_MSG_WARN([[******************************************************************]])
 	])
 
-AS_IF([test "x$ac_cv_prog_HAVE_AUTOGEN" = "xno"], [
-		AC_MSG_WARN([[Touching files in directory tests/.]])
-		touch tests/*.c tests/*.h
-	])
+AM_CONDITIONAL([HAVE_AUTOGEN], [test "x$ac_cv_prog_HAVE_AUTOGEN" = "xyes"])
 
 dnl ====================================================================================
 dnl  Settings for the HTML documentation.


### PR DESCRIPTION
* `autogen` is only required for bootstrapping the tests and not from release tarballs. Calling `touch` from configure scripts is brittle and doesn't work when `$srcdir` != `$builddir`.

Bug: https://bugs.gentoo.org/869815