### PR TITLE
Fix truncation for float to PCM

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1782,20 +1782,20 @@ static void
 f2sc_clip_array (const float *src, signed char *dest, int count, int normalize)
 {	float	normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x1000000) ;
+	normfact = normalize ? (8.0 * 0x10) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7F))
 		{	dest [i] = 127 ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x10))
 		{	dest [i] = -128 ;
 			continue ;
 			} ;
 
-		dest [i] = psf_lrintf (scaled_value) >> 24 ;
+		dest [i] = psf_lrintf (scaled_value) ;
 		} ;
 } /* f2sc_clip_array */
 
@@ -1841,20 +1841,20 @@ static	void
 f2uc_clip_array	(const float *src, unsigned char *dest, int count, int normalize)
 {	float	normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x1000000) ;
+	normfact = normalize ? (8.0 * 0x10) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7F))
 		{	dest [i] = 0xFF ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x10))
 		{	dest [i] = 0 ;
 			continue ;
 			} ;
 
-		dest [i] = (psf_lrintf (scaled_value) >> 24) + 128 ;
+		dest [i] = psf_lrintf (scaled_value) + 128 ;
 		} ;
 } /* f2uc_clip_array */
 
@@ -1907,25 +1907,25 @@ f2bes_clip_array (const float *src, short *dest, int count, int normalize)
 	float			normfact, scaled_value ;
 	int				value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x10000) ;
+	normfact = normalize ? (8.0 * 0x1000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	ucptr = (unsigned char*) &dest [i] ;
 		scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFF))
 		{	ucptr [1] = 0xFF ;
 			ucptr [0] = 0x7F ;
 			continue ;
 		} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x1000))
 		{	ucptr [1] = 0x00 ;
 			ucptr [0] = 0x80 ;
 			continue ;
 			} ;
 
 		value = psf_lrintf (scaled_value) ;
-		ucptr [1] = value >> 16 ;
-		ucptr [0] = value >> 24 ;
+		ucptr [1] = value ;
+		ucptr [0] = value >> 8 ;
 		} ;
 } /* f2bes_clip_array */
 
@@ -1978,25 +1978,25 @@ f2les_clip_array (const float *src, short *dest, int count, int normalize)
 	float			normfact, scaled_value ;
 	int				value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x10000) ;
+	normfact = normalize ? (8.0 * 0x1000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	ucptr = (unsigned char*) &dest [i] ;
 		scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFF))
 		{	ucptr [0] = 0xFF ;
 			ucptr [1] = 0x7F ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x1000))
 		{	ucptr [0] = 0x00 ;
 			ucptr [1] = 0x80 ;
 			continue ;
 			} ;
 
 		value = psf_lrintf (scaled_value) ;
-		ucptr [0] = value >> 16 ;
-		ucptr [1] = value >> 24 ;
+		ucptr [0] = value ;
+		ucptr [1] = value >> 8 ;
 		} ;
 } /* f2les_clip_array */
 
@@ -2047,12 +2047,12 @@ f2let_clip_array (const float *src, tribyte *dest, int count, int normalize)
 {	float	normfact, scaled_value ;
 	int		value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x100) ;
+	normfact = normalize ? (8.0 * 0x100000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
 #if CPU_CLIPS_POSITIVE == 0
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFFFF))
 		{	dest [i].bytes [0] = 0xFF ;
 			dest [i].bytes [1] = 0xFF ;
 			dest [i].bytes [2] = 0x7F ;
@@ -2060,7 +2060,7 @@ f2let_clip_array (const float *src, tribyte *dest, int count, int normalize)
 			} ;
 #endif
 #if CPU_CLIPS_NEGATIVE == 0
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x100000))
 		{	dest [i].bytes [0] = 0x00 ;
 			dest [i].bytes [1] = 0x00 ;
 			dest [i].bytes [2] = 0x80 ;
@@ -2069,9 +2069,9 @@ f2let_clip_array (const float *src, tribyte *dest, int count, int normalize)
 #endif
 
 		value = psf_lrintf (scaled_value) ;
-		dest [i].bytes [0] = value >> 8 ;
-		dest [i].bytes [1] = value >> 16 ;
-		dest [i].bytes [2] = value >> 24 ;
+		dest [i].bytes [0] = value ;
+		dest [i].bytes [1] = value >> 8 ;
+		dest [i].bytes [2] = value >> 16 ;
 		} ;
 } /* f2let_clip_array */
 
@@ -2122,12 +2122,12 @@ f2bet_clip_array (const float *src, tribyte *dest, int count, int normalize)
 {	float	normfact, scaled_value ;
 	int		value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x100) ;
+	normfact = normalize ? (8.0 * 0x100000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
 #if CPU_CLIPS_POSITIVE == 0
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFFFF))
 		{	dest [i].bytes [0] = 0x7F ;
 			dest [i].bytes [1] = 0xFF ;
 			dest [i].bytes [2] = 0xFF ;
@@ -2135,7 +2135,7 @@ f2bet_clip_array (const float *src, tribyte *dest, int count, int normalize)
 			} ;
 #endif
 #if CPU_CLIPS_NEGATIVE == 0
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x100000))
 		{	dest [i].bytes [0] = 0x80 ;
 			dest [i].bytes [1] = 0x00 ;
 			dest [i].bytes [2] = 0x00 ;
@@ -2144,9 +2144,9 @@ f2bet_clip_array (const float *src, tribyte *dest, int count, int normalize)
 #endif
 
 		value = psf_lrint (scaled_value) ;
-		dest [i].bytes [0] = value >> 24 ;
-		dest [i].bytes [1] = value >> 16 ;
-		dest [i].bytes [2] = value >> 8 ;
+		dest [i].bytes [0] = value >> 16 ;
+		dest [i].bytes [1] = value >> 8 ;
+		dest [i].bytes [2] = value ;
 		} ;
 } /* f2bet_clip_array */
 
@@ -2358,20 +2358,20 @@ static void
 d2sc_clip_array	(const double *src, signed char *dest, int count, int normalize)
 {	double	normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x1000000) ;
+	normfact = normalize ? (8.0 * 0x10) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7F))
 		{	dest [i] = 127 ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x10))
 		{	dest [i] = -128 ;
 			continue ;
 			} ;
 
-		dest [i] = psf_lrintf (scaled_value) >> 24 ;
+		dest [i] = psf_lrintf (scaled_value);
 		} ;
 } /* d2sc_clip_array */
 
@@ -2417,20 +2417,20 @@ static	void
 d2uc_clip_array	(const double *src, unsigned char *dest, int count, int normalize)
 {	double	normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x1000000) ;
+	normfact = normalize ? (8.0 * 0x10) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7F))
 		{	dest [i] = 255 ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x10))
 		{	dest [i] = 0 ;
 			continue ;
 			} ;
 
-		dest [i] = (psf_lrint (src [i] * normfact) >> 24) + 128 ;
+		dest [i] = psf_lrint (src [i] * normfact) + 128 ;
 		} ;
 } /* d2uc_clip_array */
 
@@ -2483,25 +2483,25 @@ d2bes_clip_array (const double *src, short *dest, int count, int normalize)
 	double			normfact, scaled_value ;
 	int				value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x10000) ;
+	normfact = normalize ? (8.0 * 0x1000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	ucptr = (unsigned char*) &dest [i] ;
 		scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFF))
 		{	ucptr [1] = 0xFF ;
 			ucptr [0] = 0x7F ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x1000))
 		{	ucptr [1] = 0x00 ;
 			ucptr [0] = 0x80 ;
 			continue ;
 			} ;
 
 		value = psf_lrint (scaled_value) ;
-		ucptr [1] = value >> 16 ;
-		ucptr [0] = value >> 24 ;
+		ucptr [1] = value ;
+		ucptr [0] = value >> 8 ;
 		} ;
 } /* d2bes_clip_array */
 
@@ -2554,25 +2554,25 @@ d2les_clip_array (const double *src, short *dest, int count, int normalize)
 	int				value ;
 	double			normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x10000) ;
+	normfact = normalize ? (8.0 * 0x1000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	ucptr = (unsigned char*) &dest [i] ;
 		scaled_value = src [i] * normfact ;
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFF))
 		{	ucptr [0] = 0xFF ;
 			ucptr [1] = 0x7F ;
 			continue ;
 			} ;
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x1000))
 		{	ucptr [0] = 0x00 ;
 			ucptr [1] = 0x80 ;
 			continue ;
 			} ;
 
 		value = psf_lrint (scaled_value) ;
-		ucptr [0] = value >> 16 ;
-		ucptr [1] = value >> 24 ;
+		ucptr [0] = value ;
+		ucptr [1] = value >> 8 ;
 		} ;
 } /* d2les_clip_array */
 
@@ -2623,12 +2623,12 @@ d2let_clip_array (const double *src, tribyte *dest, int count, int normalize)
 {	int		value ;
 	double	normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x100) ;
+	normfact = normalize ? (8.0 * 0x100000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
 #if CPU_CLIPS_POSITIVE == 0
-		if (scaled_value >= (1.0 * 0x7FFFFFFF))
+		if (scaled_value >= (1.0 * 0x7FFFFF))
 		{	dest [i].bytes [0] = 0xFF ;
 			dest [i].bytes [1] = 0xFF ;
 			dest [i].bytes [2] = 0x7F ;
@@ -2636,7 +2636,7 @@ d2let_clip_array (const double *src, tribyte *dest, int count, int normalize)
 			} ;
 #endif
 #if CPU_CLIPS_NEGATIVE == 0
-		if (scaled_value <= (-8.0 * 0x10000000))
+		if (scaled_value <= (-8.0 * 0x100000))
 		{	dest [i].bytes [0] = 0x00 ;
 			dest [i].bytes [1] = 0x00 ;
 			dest [i].bytes [2] = 0x80 ;
@@ -2645,9 +2645,9 @@ d2let_clip_array (const double *src, tribyte *dest, int count, int normalize)
 #endif
 
 		value = psf_lrint (scaled_value) ;
-		dest [i].bytes [0] = value >> 8 ;
-		dest [i].bytes [1] = value >> 16 ;
-		dest [i].bytes [2] = value >> 24 ;
+		dest [i].bytes [0] = value ;
+		dest [i].bytes [1] = value >> 8 ;
+		dest [i].bytes [2] = value >> 16 ;
 		} ;
 } /* d2let_clip_array */
 
@@ -2698,7 +2698,7 @@ d2bet_clip_array (const double *src, tribyte *dest, int count, int normalize)
 {	int		value ;
 	double	normfact, scaled_value ;
 
-	normfact = normalize ? (8.0 * 0x10000000) : (1.0 * 0x100) ;
+	normfact = normalize ? (8.0 * 0x100000) : 1.0 ;
 
 	for (int i = 0 ; i < count ; i++)
 	{	scaled_value = src [i] * normfact ;
@@ -2720,9 +2720,9 @@ d2bet_clip_array (const double *src, tribyte *dest, int count, int normalize)
 #endif
 
 		value = psf_lrint (scaled_value) ;
-		dest [i].bytes [2] = value >> 8 ;
-		dest [i].bytes [1] = value >> 16 ;
-		dest [i].bytes [0] = value >> 24 ;
+		dest [i].bytes [2] = value ;
+		dest [i].bytes [1] = value >> 8 ;
+		dest [i].bytes [0] = value >> 16 ;
 		} ;
 } /* d2bet_clip_array */
 


### PR DESCRIPTION
Instead of floor, float to int quantization should round to nearest.

In current `pcm.c`, all floating point to fixed point clipping array are scaling the number to 32-bit integer range and converted to `int` then truncate the smaller bits. This causes the number being rounded to floor instead of nearest integer. Change this to scaling to corresponding range for target data type and truncate the higher bits would fix this.