### PR TITLE
ALAC: Include config.h to avoid warnings

### DIFF
--- a/src/ALAC/ag_dec.c
+++ b/src/ALAC/ag_dec.c
@@ -26,6 +26,8 @@
 	Copyright:	(c) 2001-2011 Apple, Inc.
 */
 
+#include "config.h"
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/ALAC/ag_enc.c
+++ b/src/ALAC/ag_enc.c
@@ -27,6 +27,8 @@
 	Copyright:	(c) 2001-2011 Apple, Inc.
 */
 
+#include "config.h"
+
 #include "aglib.h"
 #include "ALACBitUtilities.h"
 #include "EndianPortable.h"

--- a/src/ALAC/alac_decoder.c
+++ b/src/ALAC/alac_decoder.c
@@ -23,6 +23,8 @@
 	File:		ALACDecoder.cpp
 */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/src/ALAC/alac_encoder.c
+++ b/src/ALAC/alac_encoder.c
@@ -28,6 +28,8 @@
 #define DebugMsg			printf
 
 // headers
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/ALAC/matrix_dec.c
+++ b/src/ALAC/matrix_dec.c
@@ -27,6 +27,8 @@
 	Copyright:	(c) 2004-2011 Apple, Inc.
 */
 
+#include "config.h"
+
 #include "matrixlib.h"
 #include "ALACAudioTypes.h"
 #include "shift.h"

--- a/src/ALAC/matrix_enc.c
+++ b/src/ALAC/matrix_enc.c
@@ -27,6 +27,8 @@
 	Copyright:	(c) 2004-2011 Apple, Inc.
 */
 
+#include "config.h"
+
 #include "matrixlib.h"
 #include "ALACAudioTypes.h"
 


### PR DESCRIPTION
Get rid of compile warnings when compiled 32-bit on illumos.
See also: https://github.com/libsndfile/libsndfile/issues/966#issuecomment-1727389036