### PR TITLE
Fix various numeric overflow vulns throughout code (CVE-2022-33065)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -456,7 +456,7 @@ if USE_OSSFUZZ_STATIC
 FUZZ_LDADD = $(LIB_FUZZING_ENGINE)
 FUZZ_FLAG =
 else
-FUZZ_LDADD = libstandaloneengine.la
+FUZZ_LDADD = ossfuzz/libstandaloneengine.la
 FUZZ_FLAG =
 endif
 endif

--- a/ossfuzz/.gitignore
+++ b/ossfuzz/.gitignore
@@ -1,1 +1,2 @@
 sndfile_fuzzer
+sndfile_alt_fuzzer

--- a/ossfuzz/sndfile_fuzz_header.h
+++ b/ossfuzz/sndfile_fuzz_header.h
@@ -1,6 +1,8 @@
 #ifndef SNDFILE_FUZZ_HEADER_H
 #define SNDFILE_FUZZ_HEADER_H
 
+#include <errno.h>
+
 typedef struct
 {
   sf_count_t offset ;
@@ -32,6 +34,9 @@ static sf_count_t vfseek (sf_count_t offset, int whence, void *user_data)
         break ;
 
     default :
+        // SEEK_DATA and SEEK_HOLE are not supported by this function.
+        errno = EINVAL ;
+        return -1 ;
         break ;
   }
 

--- a/ossfuzz/sndfile_fuzz_header.h
+++ b/ossfuzz/sndfile_fuzz_header.h
@@ -88,8 +88,7 @@ int sf_init_file(const uint8_t *data,
                 SNDFILE **sndfile, 
                 VIO_DATA *vio_data, 
                 SF_VIRTUAL_IO *vio, SF_INFO *sndfile_info)
-{  float* read_buffer = NULL ;
-
+{
    // Initialize the virtual IO structure.
    vio->get_filelen = vfget_filelen ;
    vio->seek = vfseek ;

--- a/src/aiff.c
+++ b/src/aiff.c
@@ -1702,7 +1702,7 @@ static int
 aiff_read_basc_chunk (SF_PRIVATE * psf, int datasize)
 {	const char * type_str ;
 	basc_CHUNK bc ;
-	int count ;
+	sf_count_t count ;
 
 	count = psf_binheader_readf (psf, "E442", &bc.version, &bc.numBeats, &bc.rootNote) ;
 	count += psf_binheader_readf (psf, "E222", &bc.scaleType, &bc.sigNumerator, &bc.sigDenominator) ;

--- a/src/au.c
+++ b/src/au.c
@@ -291,6 +291,7 @@ static int
 au_read_header (SF_PRIVATE *psf)
 {	AU_FMT	au_fmt ;
 	int		marker, dword ;
+	sf_count_t data_end ;
 
 	memset (&au_fmt, 0, sizeof (au_fmt)) ;
 	psf_binheader_readf (psf, "pm", 0, &marker) ;
@@ -317,14 +318,15 @@ au_read_header (SF_PRIVATE *psf)
 		return SFE_AU_EMBED_BAD_LEN ;
 		} ;
 
+	data_end = (sf_count_t) au_fmt.dataoffset + (sf_count_t) au_fmt.datasize ;
 	if (psf->fileoffset > 0)
-	{	psf->filelength = au_fmt.dataoffset + au_fmt.datasize ;
+	{	psf->filelength = data_end ;
 		psf_log_printf (psf, "  Data Size   : %d\n", au_fmt.datasize) ;
 		}
-	else if (au_fmt.datasize == -1 || au_fmt.dataoffset + au_fmt.datasize == psf->filelength)
+	else if (au_fmt.datasize == -1 || data_end == psf->filelength)
 		psf_log_printf (psf, "  Data Size   : %d\n", au_fmt.datasize) ;
-	else if (au_fmt.dataoffset + au_fmt.datasize < psf->filelength)
-	{	psf->filelength = au_fmt.dataoffset + au_fmt.datasize ;
+	else if (data_end < psf->filelength)
+	{	psf->filelength = data_end ;
 		psf_log_printf (psf, "  Data Size   : %d\n", au_fmt.datasize) ;
 		}
 	else

--- a/src/avr.c
+++ b/src/avr.c
@@ -162,7 +162,7 @@ avr_read_header (SF_PRIVATE *psf)
 	psf->endian = SF_ENDIAN_BIG ;
 
  	psf->dataoffset = AVR_HDR_SIZE ;
-	psf->datalength = hdr.frames * (hdr.rez / 8) ;
+	psf->datalength = (sf_count_t) hdr.frames * (hdr.rez / 8) ;
 
 	if (psf->fileoffset > 0)
 		psf->filelength = AVR_HDR_SIZE + psf->datalength ;

--- a/src/common.c
+++ b/src/common.c
@@ -18,6 +18,7 @@
 
 #include <config.h>
 
+#include <limits.h>
 #include <stdarg.h>
 #include <string.h>
 #if HAVE_UNISTD_H
@@ -990,6 +991,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 	double			*doubleptr ;
 	char			c ;
 	int				byte_count = 0, count = 0 ;
+	int				read_bytes = 0 ;
 
 	if (! format)
 		return psf_ftell (psf) ;
@@ -998,6 +1000,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 
 	while ((c = *format++))
 	{
+		read_bytes = 0 ;
 		if (psf->header.indx + 16 >= psf->header.len && psf_bump_header_allocation (psf, 16))
 			break ;
 
@@ -1014,7 +1017,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 					intptr = va_arg (argptr, unsigned int*) ;
 					*intptr = 0 ;
 					ucptr = (unsigned char*) intptr ;
-					byte_count += header_read (psf, ucptr, sizeof (int)) ;
+					read_bytes = header_read (psf, ucptr, sizeof (int)) ;
 					*intptr = GET_MARKER (ucptr) ;
 					break ;
 
@@ -1022,7 +1025,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 					intptr = va_arg (argptr, unsigned int*) ;
 					*intptr = 0 ;
 					ucptr = (unsigned char*) intptr ;
-					byte_count += header_read (psf, sixteen_bytes, sizeof (sixteen_bytes)) ;
+					read_bytes = header_read (psf, sixteen_bytes, sizeof (sixteen_bytes)) ;
 					{	int k ;
 						intdata = 0 ;
 						for (k = 0 ; k < 16 ; k++)
@@ -1034,14 +1037,14 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 			case '1' :
 					charptr = va_arg (argptr, char*) ;
 					*charptr = 0 ;
-					byte_count += header_read (psf, charptr, sizeof (char)) ;
+					read_bytes = header_read (psf, charptr, sizeof (char)) ;
 					break ;
 
 			case '2' : /* 2 byte value with the current endian-ness */
 					shortptr = va_arg (argptr, unsigned short*) ;
 					*shortptr = 0 ;
 					ucptr = (unsigned char*) shortptr ;
-					byte_count += header_read (psf, ucptr, sizeof (short)) ;
+					read_bytes = header_read (psf, ucptr, sizeof (short)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						*shortptr = GET_BE_SHORT (ucptr) ;
 					else
@@ -1051,7 +1054,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 			case '3' : /* 3 byte value with the current endian-ness */
 					intptr = va_arg (argptr, unsigned int*) ;
 					*intptr = 0 ;
-					byte_count += header_read (psf, sixteen_bytes, 3) ;
+					read_bytes = header_read (psf, sixteen_bytes, 3) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						*intptr = GET_BE_3BYTE (sixteen_bytes) ;
 					else
@@ -1062,7 +1065,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 					intptr = va_arg (argptr, unsigned int*) ;
 					*intptr = 0 ;
 					ucptr = (unsigned char*) intptr ;
-					byte_count += header_read (psf, ucptr, sizeof (int)) ;
+					read_bytes = header_read (psf, ucptr, sizeof (int)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						*intptr = psf_get_be32 (ucptr, 0) ;
 					else
@@ -1072,7 +1075,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 			case '8' : /* 8 byte value with the current endian-ness */
 					countptr = va_arg (argptr, sf_count_t *) ;
 					*countptr = 0 ;
-					byte_count += header_read (psf, sixteen_bytes, 8) ;
+					read_bytes = header_read (psf, sixteen_bytes, 8) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						countdata = psf_get_be64 (sixteen_bytes, 0) ;
 					else
@@ -1083,7 +1086,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 			case 'f' : /* Float conversion */
 					floatptr = va_arg (argptr, float *) ;
 					*floatptr = 0.0 ;
-					byte_count += header_read (psf, floatptr, sizeof (float)) ;
+					read_bytes = header_read (psf, floatptr, sizeof (float)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						*floatptr = float32_be_read ((unsigned char*) floatptr) ;
 					else
@@ -1093,7 +1096,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 			case 'd' : /* double conversion */
 					doubleptr = va_arg (argptr, double *) ;
 					*doubleptr = 0.0 ;
-					byte_count += header_read (psf, doubleptr, sizeof (double)) ;
+					read_bytes = header_read (psf, doubleptr, sizeof (double)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						*doubleptr = double64_be_read ((unsigned char*) doubleptr) ;
 					else
@@ -1117,7 +1120,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 					charptr = va_arg (argptr, char*) ;
 					count = va_arg (argptr, size_t) ;
 					memset (charptr, 0, count) ;
-					byte_count += header_read (psf, charptr, count) ;
+					read_bytes = header_read (psf, charptr, count) ;
 					break ;
 
 			case 'G' :
@@ -1128,7 +1131,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 					if (psf->header.indx + count >= psf->header.len && psf_bump_header_allocation (psf, count))
 						break ;
 
-					byte_count += header_gets (psf, charptr, count) ;
+					read_bytes = header_gets (psf, charptr, count) ;
 					break ;
 
 			case 'z' :
@@ -1152,7 +1155,7 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 			case 'j' :	/* Seek to position from current position. */
 					count = va_arg (argptr, size_t) ;
 					header_seek (psf, count, SEEK_CUR) ;
-					byte_count += count ;
+					read_bytes = count ;
 					break ;
 
 			case '!' : /* Clear buffer, forcing re-read. */
@@ -1164,7 +1167,16 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 				psf->error = SFE_INTERNAL ;
 				break ;
 			} ;
+
+		if (read_bytes > 0 && byte_count > (INT_MAX - read_bytes))
+		{	psf_log_printf (psf, "Header size exceeds INT_MAX. Aborting.", c) ;
+			psf->error = SFE_INTERNAL ;
+			break ;
+		} else
+		{	byte_count += read_bytes ;
 		} ;
+
+		} ;	/*end while*/
 
 	va_end (argptr) ;
 

--- a/src/common.h
+++ b/src/common.h
@@ -439,7 +439,7 @@ typedef struct sf_private_tag
 	sf_count_t		datalength ;	/* Length in bytes of the audio data. */
 	sf_count_t		dataend ;		/* Offset to file tailer. */
 
-	int				blockwidth ;	/* Size in bytes of one set of interleaved samples. */
+	sf_count_t		blockwidth ;	/* Size in bytes of one set of interleaved samples. */
 	int				bytewidth ;		/* Size in bytes of one sample (one channel). */
 
 	void			*dither ;

--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -187,7 +187,7 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 	**	to avoid having to branch when pulling apart the nibbles.
 	*/
 	count = ((samplesperblock - 2) | 7) + 2 ;
-	pimasize = sizeof (IMA_ADPCM_PRIVATE) + psf->sf.channels * (blockalign + samplesperblock + sizeof(short) * count) ;
+	pimasize = sizeof (IMA_ADPCM_PRIVATE) + psf->sf.channels * (blockalign + samplesperblock + sizeof (short) * count) ;
 
 	if (! (pima = calloc (1, pimasize)))
 		return SFE_MALLOC_FAILED ;
@@ -238,7 +238,7 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 		case SF_FORMAT_AIFF :
 				psf_log_printf (psf, "still need to check block count\n") ;
 				pima->decode_block = aiff_ima_decode_block ;
-				psf->sf.frames = pima->samplesperblock * pima->blocks / pima->channels ;
+				psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blocks / pima->channels ;
 				break ;
 
 		default :
@@ -391,7 +391,7 @@ aiff_ima_encode_block (SF_PRIVATE *psf, IMA_ADPCM_PRIVATE *pima)
 static int
 wavlike_ima_decode_block (SF_PRIVATE *psf, IMA_ADPCM_PRIVATE *pima)
 {	int		chan, k, predictor, blockindx, indx, indxstart, diff ;
-	short	step, bytecode, stepindx [2] = { 0 };
+	short	step, bytecode, stepindx [2] = { 0 } ;
 
 	pima->blockcount ++ ;
 	pima->samplecount = 0 ;

--- a/src/ircam.c
+++ b/src/ircam.c
@@ -171,35 +171,35 @@ ircam_read_header	(SF_PRIVATE *psf)
 	switch (encoding)
 	{	case IRCAM_PCM_16 :
 				psf->bytewidth = 2 ;
-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_PCM_16 ;
 				break ;
 
 		case IRCAM_PCM_32 :
 				psf->bytewidth = 4 ;
-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_PCM_32 ;
 				break ;
 
 		case IRCAM_FLOAT :
 				psf->bytewidth = 4 ;
-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_FLOAT ;
 				break ;
 
 		case IRCAM_ALAW :
 				psf->bytewidth = 1 ;
-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_ALAW ;
 				break ;
 
 		case IRCAM_ULAW :
 				psf->bytewidth = 1 ;
-				psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+				psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 				psf->sf.format = SF_FORMAT_IRCAM | SF_FORMAT_ULAW ;
 				break ;

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -320,7 +320,7 @@ mat4_read_header (SF_PRIVATE *psf)
 				psf->filelength - psf->dataoffset, psf->sf.channels * psf->sf.frames * psf->bytewidth) ;
 		}
 	else if ((psf->filelength - psf->dataoffset) > psf->sf.channels * psf->sf.frames * psf->bytewidth)
-		psf->dataend = psf->dataoffset + rows * cols * psf->bytewidth ;
+		psf->dataend = psf->dataoffset + (sf_count_t) rows * (sf_count_t) cols * psf->bytewidth ;
 
 	psf->datalength = psf->filelength - psf->dataoffset - psf->dataend ;
 

--- a/src/mat4.c
+++ b/src/mat4.c
@@ -104,7 +104,7 @@ mat4_open	(SF_PRIVATE *psf)
 
 	psf->container_close = mat4_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_PCM_16 :

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -114,7 +114,7 @@ mat5_open	(SF_PRIVATE *psf)
 
 	psf->container_close = mat5_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_PCM_U8 :

--- a/src/nms_adpcm.c
+++ b/src/nms_adpcm.c
@@ -48,36 +48,36 @@
 /* Variable names from ITU G.726 spec */
 struct nms_adpcm_state
 {	/* Log of the step size multiplier. Operated on by codewords. */
-	int yl ;
+	short yl ;
 
 	/* Quantizer step size multiplier. Generated from yl. */
-	int y ;
+	short y ;
 
 	/* Coefficients of the pole predictor */
-	int a [2] ;
+	short a [2] ;
 
 	/* Coefficients of the zero predictor  */
-	int b [6] ;
+	short b [6] ;
 
 	/* Previous quantized deltas (multiplied by 2^14) */
-	int d_q [7] ;
+	short d_q [7] ;
 
 	/* d_q [x] + s_ez [x], used by the pole-predictor for signs only. */
-	int p [3] ;
+	short p [3] ;
 
 	/* Previous reconstructed signal values. */
-	int s_r [2] ;
+	short s_r [2] ;
 
 	/* Zero predictor components of the signal estimate. */
-	int s_ez ;
+	short s_ez ;
 
 	/* Signal estimate, (including s_ez). */
-	int s_e ;
+	short s_e ;
 
 	/* The most recent codeword (enc:generated, dec:inputted) */
-	int Ik ;
+	char Ik ;
 
-	int parity ;
+	char parity ;
 
 	/*
 	** Offset into code tables for the bitrate.
@@ -109,7 +109,7 @@ typedef struct
 } NMS_ADPCM_PRIVATE ;
 
 /* Pre-computed exponential interval used in the antilog approximation. */
-static unsigned int table_expn [] =
+static unsigned short table_expn [] =
 {	0x4000, 0x4167, 0x42d5, 0x444c,	0x45cb, 0x4752, 0x48e2, 0x4a7a,
 	0x4c1b, 0x4dc7, 0x4f7a, 0x5138,	0x52ff, 0x54d1, 0x56ac, 0x5892,
 	0x5a82, 0x5c7e, 0x5e84, 0x6096,	0x62b4, 0x64dd, 0x6712, 0x6954,
@@ -117,21 +117,21 @@ static unsigned int table_expn [] =
 } ;
 
 /* Table mapping codewords to scale factor deltas. */
-static int table_scale_factor_step [] =
+static short table_scale_factor_step [] =
 {	0x0,	0x0,	0x0,	0x0,	0x4b0,	0x0,	0x0,	0x0,	/* 2-bit */
 	-0x3c,	0x0,	0x90,	0x0,	0x2ee,	0x0,	0x898,	0x0,	/* 3-bit */
 	-0x30,	0x12,	0x6b,	0xc8,	0x188,	0x2e0,	0x551,	0x1150,	/* 4-bit */
 } ;
 
 /* Table mapping codewords to quantized delta interval steps. */
-static unsigned int table_step [] =
+static unsigned short table_step [] =
 {	0x73F,	0,		0,		0,		0x1829,	0,		0,		0,		/* 2-bit */
 	0x3EB,	0,		0xC18,	0,		0x1581,	0,		0x226E,	0,		/* 3-bit */
 	0x20C,	0x635,	0xA83,	0xF12,	0x1418,	0x19E3,	0x211A,	0x2BBA,	/* 4-bit */
 } ;
 
 /* Binary search lookup table for quantizing using table_step. */
-static int table_step_search [] =
+static short table_step_search [] =
 {	0,		0x1F6D,	0,		-0x1F6D,	0,		0,			0,			0, /* 2-bit */
 	0x1008,	0x1192,	0,		-0x219A,	0x1656,	-0x1656,	0,			0, /* 3-bit */
 	0x872,	0x1277,	-0x8E6,	-0x232B,	0xD06,	-0x17D7,	-0x11D3,	0, /* 4-bit */
@@ -179,23 +179,23 @@ static sf_count_t nms_adpcm_seek (SF_PRIVATE *psf, int mode, sf_count_t offset) 
 ** Maps [1,20480] to [1,1024] in an exponential relationship. This is
 ** approximately ret = b^exp where b = e^(ln(1024)/ln(20480)) ~= 1.0003385
 */
-static inline int
-nms_adpcm_antilog (int exp)
-{	int ret ;
+static inline short
+nms_adpcm_antilog (short exp)
+{	int_fast32_t r ;
 
-	ret = 0x1000 ;
-	ret += (((exp & 0x3f) * 0x166b) >> 12) ;
-	ret *= table_expn [(exp & 0x7c0) >> 6] ;
-	ret >>= (26 - (exp >> 11)) ;
+	r = 0x1000 ;
+	r += (((int_fast32_t) (exp & 0x3f) * 0x166b) >> 12) ;
+	r *= table_expn [(exp & 0x7c0) >> 6] ;
+	r >>= (26 - (exp >> 11)) ;
 
-	return ret ;
+	return (short) r ;
 } /* nms_adpcm_antilog */
 
 static void
 nms_adpcm_update (struct nms_adpcm_state *s)
 {	/* Variable names from ITU G.726 spec */
-	int a1ul ;
-	int fa1 ;
+	short a1ul, fa1 ;
+	int_fast32_t se ;
 	int i ;
 
 	/* Decay and Modify the scale factor in the log domain based on the codeword. */
@@ -222,7 +222,7 @@ nms_adpcm_update (struct nms_adpcm_state *s)
 	else if (fa1 > 256)
 		fa1 = 256 ;
 
-	s->a [0] = (0xff * s->a [0]) >> 8 ;
+	s->a [0] = (s->a [0] * 0xff) >> 8 ;
 	if (s->p [0] != 0 && s->p [1] != 0 && ((s->p [0] ^ s->p [1]) < 0))
 		s->a [0] -= 192 ;
 	else
@@ -230,7 +230,7 @@ nms_adpcm_update (struct nms_adpcm_state *s)
 		fa1 = -fa1 ;
 		}
 
-	s->a [1] = fa1 + ((0xfe * s->a [1]) >> 8) ;
+	s->a [1] = fa1 + ((s->a [1] * 0xfe) >> 8) ;
 	if (s->p [0] != 0 && s->p [2] != 0 && ((s->p [0] ^ s->p [2]) < 0))
 		s->a [1] -= 128 ;
 	else
@@ -250,19 +250,18 @@ nms_adpcm_update (struct nms_adpcm_state *s)
 			s->a [0] = a1ul ;
 		} ;
 
-	/* Compute the zero predictor estimate. Rotate past deltas too. */
-	s->s_ez = 0 ;
+	/* Compute the zero predictor estimate and rotate past deltas. */
+	se = 0 ;
 	for (i = 5 ; i >= 0 ; i--)
-	{	s->s_ez += s->d_q [i] * s->b [i] ;
+	{	se += (int_fast32_t) s->d_q [i] * s->b [i] ;
 		s->d_q [i + 1] = s->d_q [i] ;
 		} ;
+	s->s_ez = se >> 14 ;
 
-	/* Compute the signal estimate. */
-	s->s_e = s->a [0] * s->s_r [0] + s->a [1] * s->s_r [1] + s->s_ez ;
-
-	/* Return to scale */
-	s->s_ez >>= 14 ;
-	s->s_e >>= 14 ;
+	/* Complete the signal estimate. */
+	se += (int_fast32_t) s->a [0] * s->s_r [0] ;
+	se += (int_fast32_t) s->a [1] * s->s_r [1] ;
+	s->s_e = se >> 14 ;
 
 	/* Rotate members to prepare for next iteration. */
 	s->s_r [1] = s->s_r [0] ;
@@ -274,7 +273,7 @@ nms_adpcm_update (struct nms_adpcm_state *s)
 static int16_t
 nms_adpcm_reconstruct_sample (struct nms_adpcm_state *s, uint8_t I)
 {	/* Variable names from ITU G.726 spec */
-	int dqx ;
+	int_fast32_t dqx ;
 
 	/*
 	** The ordering of the 12-bit right-shift is a precision loss. It agrees
@@ -308,17 +307,17 @@ nms_adpcm_codec_init (struct nms_adpcm_state *s, enum nms_enc_type type)
 /*
 ** nms_adpcm_encode_sample()
 **
-** Encode a linear 16-bit pcm sample into a 2,3, or 4 bit NMS-ADPCM codeword
+** Encode a linear 16-bit pcm sample into a 2, 3, or 4 bit NMS-ADPCM codeword
 ** using and updating the predictor state.
 */
 static uint8_t
 nms_adpcm_encode_sample (struct nms_adpcm_state *s, int16_t sl)
 {	/* Variable names from ITU G.726 spec */
-	int d ;
+	int_fast32_t d ;
 	uint8_t I ;
 
 	/* Down scale the sample from 16 => ~14 bits. */
-	sl = (sl * 0x1fdf) / 0x7fff ;
+	sl = ((int_fast32_t) sl * 0x1fdf) / 0x7fff ;
 
 	/* Compute estimate, and delta from actual value */
 	nms_adpcm_update (s) ;
@@ -407,7 +406,7 @@ nms_adpcm_encode_sample (struct nms_adpcm_state *s, int16_t sl)
 */
 static int16_t
 nms_adpcm_decode_sample (struct nms_adpcm_state *s, uint8_t I)
-{	int sl ;
+{	int_fast32_t sl ;
 
 	nms_adpcm_update (s) ;
 	sl = nms_adpcm_reconstruct_sample (s, I) ;

--- a/src/nms_adpcm.c
+++ b/src/nms_adpcm.c
@@ -1090,7 +1090,7 @@ nms_adpcm_init (SF_PRIVATE *psf)
 	else
 		pnms->blocks_total = psf->datalength / (pnms->shortsperblock * sizeof (short)) ;
 
-	psf->sf.frames		= pnms->blocks_total * NMS_SAMPLES_PER_BLOCK ;
+	psf->sf.frames		= (sf_count_t) pnms->blocks_total * NMS_SAMPLES_PER_BLOCK ;
 	psf->codec_close	= nms_adpcm_close ;
 	psf->seek			= nms_adpcm_seek ;
 

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -127,7 +127,7 @@ pcm_init (SF_PRIVATE *psf)
 		return SFE_INTERNAL ;
 		} ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	if ((SF_CODEC (psf->sf.format)) == SF_FORMAT_PCM_S8)
 		chars = SF_CHARS_SIGNED ;

--- a/src/rf64.c
+++ b/src/rf64.c
@@ -242,7 +242,7 @@ rf64_read_header (SF_PRIVATE *psf, int *blockalign, int *framesperblock)
 							} ;
 						} ;
 
-					if (psf->filelength != riff_size + 8)
+					if (psf->filelength - 8 != riff_size)
 						psf_log_printf (psf, "  Riff size : %D (should be %D)\n", riff_size, psf->filelength - 8) ;
 					else
 						psf_log_printf (psf, "  Riff size : %D\n", riff_size) ;

--- a/src/sds.c
+++ b/src/sds.c
@@ -454,7 +454,7 @@ sds_2byte_read (SF_PRIVATE *psf, SDS_PRIVATE *psds)
 
 	ucptr = psds->read_data + 5 ;
 	for (k = 0 ; k < 120 ; k += 2)
-	{	sample = arith_shift_left (ucptr [k], 25) + arith_shift_left (ucptr [k + 1], 18) ;
+	{	sample = arith_shift_left (ucptr [k], 25) | arith_shift_left (ucptr [k + 1], 18) ;
 		psds->read_samples [k / 2] = (int) (sample - 0x80000000) ;
 		} ;
 
@@ -498,7 +498,7 @@ sds_3byte_read (SF_PRIVATE *psf, SDS_PRIVATE *psds)
 
 	ucptr = psds->read_data + 5 ;
 	for (k = 0 ; k < 120 ; k += 3)
-	{	sample = (((uint32_t) ucptr [k]) << 25) + (ucptr [k + 1] << 18) + (ucptr [k + 2] << 11) ;
+	{	sample = (((uint32_t) ucptr [k]) << 25) | (ucptr [k + 1] << 18) | (ucptr [k + 2] << 11) ;
 		psds->read_samples [k / 3] = (int) (sample - 0x80000000) ;
 		} ;
 
@@ -542,7 +542,7 @@ sds_4byte_read (SF_PRIVATE *psf, SDS_PRIVATE *psds)
 
 	ucptr = psds->read_data + 5 ;
 	for (k = 0 ; k < 120 ; k += 4)
-	{	sample = (((uint32_t) ucptr [k]) << 25) + (ucptr [k + 1] << 18) + (ucptr [k + 2] << 11) + (ucptr [k + 3] << 4) ;
+	{	sample = (((uint32_t) ucptr [k]) << 25) | (ucptr [k + 1] << 18) | (ucptr [k + 2] << 11) | (ucptr [k + 3] << 4) ;
 		psds->read_samples [k / 4] = (int) (sample - 0x80000000) ;
 		} ;
 


### PR DESCRIPTION
Issues #789 and #833 alert that the clang fuzzer reports several numeric overflow possibilities throughout the codebase, which can lead to undefined behaviors. MITRE opened [CVE-2022-33065](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-33065) against these issues, and has issued them a high severity. This PR attempts to fix all the outstanding numeric overflows, as detected by the ossfuzzer tool, and the reproducing case from #789.

```
src/au.c:324:54: runtime error: signed integer overflow: 1684960000 + 779316836 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/au.c:324:54 in 
src/au.c:326:29: runtime error: signed integer overflow: 1684960000 + 779316836 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/au.c:326:29 in 
src/au.c:327:40: runtime error: signed integer overflow: 1684960000 + 779316836 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/au.c:327:40 in 
--
src/mat4.c:323:41: runtime error: signed integer overflow: -587202559 * 553648128 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat4.c:323:41 in 
src/mat4.c:323:48: runtime error: signed integer overflow: 553648128 * 8 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat4.c:323:48 in 
src/mat4.c:107:35: runtime error: signed integer overflow: 8 * -587202559 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat4.c:107:35 in 
--
src/mat4.c:107:35: runtime error: signed integer overflow: 8 * -452984831 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat4.c:107:35 in 
--
src/avr.c:165:31: runtime error: signed integer overflow: 1862270847 * 2 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/avr.c:165:31 in 
--
src/sds.c:457:46: runtime error: signed integer overflow: 2113929216 + 66846720 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/sds.c:457:46 in 
--
src/sds.c:457:46: runtime error: signed integer overflow: 2113929216 + 60030976 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/sds.c:457:46 in 
--
src/sds.c:457:46: runtime error: signed integer overflow: 2113929216 + 66846720 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/sds.c:457:46 in 
--
src/nms_adpcm.c:261:20: runtime error: signed integer overflow: 27648 * 78866 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/nms_adpcm.c:261:20 in 
src/nms_adpcm.c:261:33: runtime error: signed integer overflow: -2114480128 + -943374336 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/nms_adpcm.c:261:33 in 
--
src/ircam.c:181:40: runtime error: signed integer overflow: -2147483521 * 4 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/ircam.c:181:40 in 
src/pcm.c:130:35: runtime error: signed integer overflow: 4 * -2147483521 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/pcm.c:130:35 in 
--
src/nms_adpcm.c:1094:39: runtime error: signed integer overflow: 409044504 * 160 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/nms_adpcm.c:1094:39 in 
--
src/common.c:1155:17: runtime error: signed integer overflow: 2 + 2147483646 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/common.c:1155:17 in 
--
src/ima_adpcm.c:241:44: runtime error: signed integer overflow: 64 * -34645767 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/ima_adpcm.c:241:44 in 
--
src/rf64.c:245:39: runtime error: signed integer overflow: 9223372036854775807 + 8 cannot be represented in type 'long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/rf64.c:245:39 in 
--
src/sds.c:457:46: runtime error: signed integer overflow: 2113929216 + 66846720 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/sds.c:457:46 in 
--
src/aiff.c:1709:8: runtime error: signed integer overflow: 16 + 2147483637 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/aiff.c:1709:8 in 
--
src/mat5.c:117:35: runtime error: signed integer overflow: 8 * -1294148387 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/mat5.c:117:35 in
```

I tried to limit the impact of this patchset as much as is possible. But I'm just passing through this project and have very little domain knowledge. I would appreciate an ACK from the code experts that my changes make sense. I'll mark the changes which I think are non-trivial in commentary below.


# Testing
This patchset was developed and tested primarily on clang 15. I have tested somewhat with clang 13 as well, which behaved consistently. I found Google's `gcr.io/oss-fuzz-base/base-builder` container provided the best toolchain to run the ossfuzzer.

* [x] `make check` passes with this patchset applied.
  * Log attached as `check.f.log`. The `UndefinedBehaviorSanitizer` warnings from `cue_test_var 101` reproduce with and without this patchset, and are probably expected - given that the test configuration seems to be testing a purposefully invalid case.
* [x] With this patchset in place, `ossfuzz/ossfuzz.sh` runs without reporting any of the numeric overflow warnings from above or from #833.
  * Log attached as `ossfuzzer.f.log`. The various nonfatal `Error {1,A}` lines reproduce on my machine with and without this patchset. I'm not sure what they are supposed to mean. But they seem unrelated.
* [x] Running `libsnfile-metadata-get` on the reproducing test load provided in #789 no longer produces the sanitizer warning reported in the issue.

That's all the testing that I know to run. If there are other cases that I should check, please let me know.

# Merging
This patchset includes some minor fixes to the ossfuzz tooling, that I had to make to get it working on my machine. I expect they will partially conflict with #976. I can rebase and adjust depending on which of us is pulled first.

[check.f.log](https://github.com/libsndfile/libsndfile/files/12959651/check.f.log)
[ossfuzzer.f.log](https://github.com/libsndfile/libsndfile/files/12959668/ossfuzzer.f.log)
