### PR TITLE
configure.ac: fix bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -561,11 +561,11 @@ common_cflags="${common_flags}"
 dnl Clang doesn't know about -Wno-format-truncation
 dnl and would spew tons of warnings otherwise.
 AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [
-		common_cflags+=" -Wno-format-truncation"
+		common_cflags="${common_cflags} -Wno-format-truncation"
 	])
 common_cxxflags="${common_flags}"
 AS_IF([test "x$ax_cv_cxx_compiler_vendor" = "xgnu"], [
-		common_cxxflags+=" -Wno-format-truncation"
+		common_cxxflags="${common_cxxflags} -Wno-format-truncation"
 	])
 
 AX_APPEND_COMPILE_FLAGS([${common_cflags} -Wvla -Wbad-function-cast -Wnested-externs -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Waggregate-return], [CFLAGS])


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '+='.

This retains compatibility with bash.

```
 * QA Notice: command not found:
 *
 *      /var/tmp/portage/media-libs/libsndfile-1.2.2-r2/work/libsndfile-1.2.2/configure: 25166: common_cflags+= -Wno-format-truncation: not found
 *      /var/tmp/portage/media-libs/libsndfile-1.2.2-r2/work/libsndfile-1.2.2/configure: 25173: common_cxxflags+= -Wno-format-truncation: not found
```