### PR TITLE
Improvements for the Sndio backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,8 +566,9 @@ if (BUILD_PROGRAMS)
 	elseif ((NOT BEOS) AND ALSA_FOUND)
 		target_include_directories (sndfile-play PRIVATE ${ALSA_INCLUDE_DIRS})
 		target_link_libraries (sndfile-play PRIVATE ${ALSA_LIBRARIES})
-	elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-		target_link_libraries (sndfile-play PRIVATE Sndio::Sndio)
+	elseif ((NOT BEOS) AND SNDIO_FOUND)
+		target_include_directories (sndfile-play PRIVATE ${SNDIO_INCLUDE_DIRS})
+		target_link_libraries (sndfile-play PRIVATE ${SNDIO_LIBRARIES})
 	endif ()
 
 # sndfile-convert

--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -15,10 +15,9 @@ if (LARGE_FILES_DEFINITIONS)
 	add_definitions(${LARGE_FILES_DEFINITIONS})
 endif ()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-	find_package (Sndio)
-elseif (NOT WIN32)
+if (NOT WIN32)
 	find_package (ALSA)
+	find_package (Sndio)
 endif ()
 
 if (VCPKG_TOOLCHAIN AND (NOT CMAKE_VERSION VERSION_LESS 3.15))

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,9 @@ AC_ARG_ENABLE([sqlite],
 AC_ARG_ENABLE([alsa],
 	[AS_HELP_STRING([--disable-alsa], [disable ALSA support (default=autodetect)])], [], [enable_alsa=auto])
 
+AC_ARG_ENABLE([sndio],
+	[AS_HELP_STRING([--disable-sndio], [disable Sndio support (default=autodetect)])], [], [enable_sndio=auto])
+
 AC_ARG_ENABLE([external-libs],
 	[AS_HELP_STRING([--disable-external-libs], [disable use of FLAC, Ogg and Vorbis [[default=no]]])])
 
@@ -471,20 +474,26 @@ AS_IF([test "x$enable_alsa" != "xno"], [
 	])
 
 dnl ====================================================================================
-dnl  Check for OpenBSD's sndio.
+dnl  Check for Sndio.
 
-SNDIO_LIBS=""
-HAVE_SNDIO_H=0
-AS_CASE([$host_os],
-	[openbsd*], [
-		AC_CHECK_HEADERS(sndio.h)
-		AS_IF([test "x$ac_cv_header_sndio_h" = "xyes"], [
-				SNDIO_LIBS="-lsndio"
-				HAVE_SNDIO_H=1
+AS_IF([test "x$enable_sndio" != "xno"], [
+		PKG_CHECK_MODULES([SNDIO], [sndio], [
+				AC_DEFINE([HAVE_SNDIO_H], [1], [Set to 1 if <sndio.h> is available.])
+				ac_cv_sndio="yes"
+			], [
+				ac_cv_sndio="no"
+			])
+
+		AS_IF([test "x$ac_cv_sndio" = "xno"], [
+				AS_IF([test "x$enable_sndio" = "xyes"], [
+						dnl explicitly passed --enable-sndio, hence error out loud and clearly
+						AC_MSG_ERROR([You explicitly requested sndio support, but sndio could not be found!])
+                                        ], [
+						dnl did not explicitly pass --enable-sndio, relying on default automagic on
+						enable_sndio="no (auto)"
+					])
 			])
 	])
-
-AC_DEFINE_UNQUOTED([HAVE_SNDIO_H], [${HAVE_SNDIO_H}], [Set to 1 if <sndio.h> is available.])
 
 dnl ====================================================================================
 dnl  Test for sanity when cross-compiling.

--- a/man/sndfile-play.1
+++ b/man/sndfile-play.1
@@ -14,11 +14,11 @@ output APIs. The following table summarizes which audio API is used where:
 .Pp
 .Bl -tag -width MacOSX10XXX -compact
 .It Linux
-ALSA or OSS
+ALSA, OSS or sndio
 .It OpenBSD
 sndio
 .It FreeBSD
-/dev/dsp (OSS)
+/dev/dsp (OSS) or sndio
 .It NetBSD
 /dev/audio
 .It Solaris

--- a/programs/sndfile-play.c
+++ b/programs/sndfile-play.c
@@ -666,7 +666,7 @@ win32_play (int argc, char *argv [])
 #endif /* Win32 */
 
 /*------------------------------------------------------------------------------
-**	OpenBSD's sndio.
+**	Sndio.
 */
 
 #if HAVE_SNDIO_H


### PR DESCRIPTION
Move the Sndio backend away from being OpenBSD specific and
make use of the pkg-config support.

Sndio is also used on FreeBSD and Linux.