### PR TITLE
aiff: use fl32 & fl64 for COMM encoding on header write

### DIFF
--- a/src/aiff.c
+++ b/src/aiff.c
@@ -1336,14 +1336,14 @@ aiff_write_header (SF_PRIVATE *psf, int calc_length)
 				psf->endian = SF_ENDIAN_BIG ;
 				comm_type = AIFC_MARKER ;
 				comm_size = SIZEOF_AIFC_COMM ;
-				comm_encoding = FL32_MARKER ;	/* Use 'FL32' because its easier to read. */
+				comm_encoding = fl32_MARKER ;
 				break ;
 
 		case SF_FORMAT_DOUBLE :					/* Big endian double precision floating point. */
 				psf->endian = SF_ENDIAN_BIG ;
 				comm_type = AIFC_MARKER ;
 				comm_size = SIZEOF_AIFC_COMM ;
-				comm_encoding = FL64_MARKER ;	/* Use 'FL64' because its easier to read. */
+				comm_encoding = fl64_MARKER ;
 				break ;
 
 		case SF_FORMAT_ULAW :


### PR DESCRIPTION
According to the few documentations on AIFF & AIFC specs, these _lower_ case compression type markers (`fl32` & `fl64`) are commonly used and accepted by Apple for float & double format.

- [Wikipedia::AIFF::common compression types](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format#Common_compression_types)
- [McGill::AIFF Format Specifications](https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/AIFF.html)

Certain Apple DAW/utilities (such as Logic Pro) seem to dismiss AIFF files with upper case markers.

Also other libraries apply the lower case markers when writing the compression type into AIFC COMM chunk:
- [audiofile](https://github.com/mpruett/audiofile/blob/master/libaudiofile/AIFF.cpp#L838)
- [sox](https://sourceforge.net/p/sox/code/ci/master/tree/src/aiff.c#l883)