### PR TITLE
sndfile.hh: add `operator !=`

### DIFF
--- a/include/sndfile.hh
+++ b/include/sndfile.hh
@@ -111,6 +111,7 @@ class SndfileHandle
 		operator bool () const { return (p != SF_NULL) ; }
 
 		bool operator == (const SndfileHandle &rhs) const { return (p == rhs.p) ; }
+		bool operator != (const SndfileHandle &rhs) const { return !(*this == rhs); }
 
 		sf_count_t	frames (void) const		{ return p ? p->sfinfo.frames : 0 ; }
 		int			format (void) const		{ return p ? p->sfinfo.format : 0 ; }


### PR DESCRIPTION
Might as well provide `operator !=` for a complete set of comparison operators