### PR TITLE
ci: update Github action/checkout to v4

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -178,7 +178,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install MacOS dependencies
         if: startsWith(matrix.os,'macos')


### PR DESCRIPTION
Update CI use of actions/checkout to version 4, addressing Github deprecation of actions that use older versions of nodejs.

Addresses #1024