### PR TITLE
Add support for additional metadata strings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -529,18 +529,23 @@ These functions allow strings to be set on files opened for write and to be
 retrieved from files opened for read where supported by the given file type. The
 **str_type** parameter can be any one of the following string types:
 
-| Name               | Value | Description   |
-|:-------------------|:------|:--------------|
-| SF_STR_TITLE       | 0x01  | Title.        |
-| SF_STR_COPYRIGHT   | 0x02  | Copyright.    |
-| SF_STR_SOFTWARE    | 0x03  | Software.     |
-| SF_STR_ARTIST      | 0x04  | Artist.       |
-| SF_STR_COMMENT     | 0x05  | Comment.      |
-| SF_STR_DATE        | 0x06  | Date.         |
-| SF_STR_ALBUM       | 0x07  | Album.        |
-| SF_STR_LICENSE     | 0x08  | License.      |
-| SF_STR_TRACKNUMBER | 0x09  | Track number. |
-| SF_STR_GENRE       | 0x10  | Genre.        |
+| Name               | Value | Description                            |
+|:-------------------|:------|:---------------------------------------|
+| SF_STR_TITLE       | 0x01  | Title.                                 |
+| SF_STR_COPYRIGHT   | 0x02  | Copyright.                             |
+| SF_STR_SOFTWARE    | 0x03  | Software.                              |
+| SF_STR_ARTIST      | 0x04  | Artist.                                |
+| SF_STR_COMMENT     | 0x05  | Comment.                               |
+| SF_STR_DATE        | 0x06  | Date.                                  |
+| SF_STR_ALBUM       | 0x07  | Album.                                 |
+| SF_STR_LICENSE     | 0x08  | License.                               |
+| SF_STR_TRACKNUMBER | 0x09  | Track number.                          |
+| SF_STR_DISCNUMBER  | 0x0a  | Disc number.                           |
+| SF_STR_ALBUMARTIST | 0x0b  | Album artist.                          |
+| SF_STR_PERFORMER   | 0x0c  | Performer.                             |
+| SF_STR_LABEL       | 0x0d  | Record label.                          |
+| SF_STR_ISRC        | 0x0e  | International Standard Recording Code. |
+| SF_STR_GENRE       | 0x10  | Genre.                                 |
 
 The sf_get_string() function returns the specified string if it exists and a
 NULL pointer otherwise. In addition to the string ids above, SF_STR_FIRST (==

--- a/include/sndfile.h
+++ b/include/sndfile.h
@@ -269,6 +269,11 @@ enum
 	SF_STR_ALBUM					= 0x07,
 	SF_STR_LICENSE					= 0x08,
 	SF_STR_TRACKNUMBER				= 0x09,
+	SF_STR_DISCNUMBER				= 0x0a,
+	SF_STR_ALBUMARTIST				= 0x0b,
+	SF_STR_PERFORMER				= 0x0c,
+	SF_STR_LABEL					= 0x0d,
+	SF_STR_ISRC						= 0x0e,
 	SF_STR_GENRE					= 0x10
 } ;
 

--- a/src/flac.c
+++ b/src/flac.c
@@ -420,6 +420,11 @@ sf_flac_meta_get_vorbiscomments (SF_PRIVATE *psf, const FLAC__StreamMetadata *me
 		{ "album", SF_STR_ALBUM },
 		{ "license", SF_STR_LICENSE },
 		{ "tracknumber", SF_STR_TRACKNUMBER },
+		{ "discnumber", SF_STR_DISCNUMBER },
+		{ "albumartist", SF_STR_ALBUMARTIST },
+		{ "performer", SF_STR_PERFORMER },
+		{ "label", SF_STR_LABEL },
+		{ "isrc", SF_STR_ISRC },
 		{ "genre", SF_STR_GENRE }
 		} ;
 
@@ -636,6 +641,21 @@ flac_write_strings (SF_PRIVATE *psf, FLAC_PRIVATE* pflac)
 				break ;
 			case SF_STR_TRACKNUMBER :
 				key = "tracknumber" ;
+				break ;
+			case SF_STR_DISCNUMBER :
+				key = "discnumber" ;
+				break ;
+			case SF_STR_ALBUMARTIST :
+				key = "albumartist" ;
+				break ;
+			case SF_STR_PERFORMER :
+				key = "performer" ;
+				break ;
+			case SF_STR_LABEL :
+				key = "label" ;
+				break ;
+			case SF_STR_ISRC :
+				key = "isrc" ;
 				break ;
 			case SF_STR_GENRE :
 				key = "genre" ;

--- a/src/mpeg_decode.c
+++ b/src/mpeg_decode.c
@@ -358,6 +358,11 @@ mpeg_decoder_read_strings_id3v2 (SF_PRIVATE *psf, mpg123_id3v2 *tags)
 	const char *album		= NULL ;
 	const char *license		= NULL ;
 	const char *tracknumber	= NULL ;
+	const char *discnumber	= NULL ;
+	const char *albumartist	= NULL ;
+	const char *performer	= NULL ;
+	const char *label		= NULL ;
+	const char *isrc		= NULL ;
 	const char *genre		= NULL ;
 	const char *tlen		= NULL ;
 
@@ -413,6 +418,26 @@ mpeg_decoder_read_strings_id3v2 (SF_PRIVATE *psf, mpg123_id3v2 *tags)
 				tracknumber = text_frame->text.p ;
 				break ;
 
+			case MAKE_MARKER ('T', 'P', 'O', 'S') :
+				discnumber = text_frame->text.p ;
+				break ;
+
+			case MAKE_MARKER ('T', 'P', 'E', '2') :
+				albumartist = text_frame->text.p ;
+				break ;
+
+			case MAKE_MARKER ('T', 'P', 'L', 'S') :
+				performer = text_frame->text.p ;
+				break ;
+
+			case MAKE_MARKER ('T', 'P', 'U', 'B') :
+				label = text_frame->text.p ;
+				break ;
+
+			case MAKE_MARKER ('T', 'S', 'R', 'C') :
+				isrc = text_frame->text.p ;
+				break ;
+
 			case MAKE_MARKER ('T', 'C', 'O', 'N') :
 				genre = text_frame->text.p ;
 				break ;
@@ -457,6 +482,16 @@ mpeg_decoder_read_strings_id3v2 (SF_PRIVATE *psf, mpg123_id3v2 *tags)
 		psf_store_string (psf, SF_STR_LICENSE, license) ;
 	if (tracknumber != NULL)
 		psf_store_string (psf, SF_STR_TRACKNUMBER, tracknumber) ;
+	if (discnumber != NULL)
+		psf_store_string (psf, SF_STR_DISCNUMBER, discnumber) ;
+	if (albumartist != NULL)
+		psf_store_string (psf, SF_STR_ALBUMARTIST, albumartist) ;
+	if (performer != NULL)
+		psf_store_string (psf, SF_STR_PERFORMER, performer) ;
+	if (label != NULL)
+		psf_store_string (psf, SF_STR_LABEL, label) ;
+	if (isrc != NULL)
+		psf_store_string (psf, SF_STR_ISRC, isrc) ;
 	if (genre != NULL)
 		psf_store_string (psf, SF_STR_GENRE, id3_process_v2_genre (genre)) ;
 	if (tlen != NULL)

--- a/src/ogg_vcomment.c
+++ b/src/ogg_vcomment.c
@@ -49,6 +49,11 @@ static STR_PAIR vorbiscomment_mapping [] =
 	{	SF_STR_ALBUM,		"ALBUM"			},
 	{	SF_STR_LICENSE,		"LICENSE",		},
 	{	SF_STR_TRACKNUMBER,	"TRACKNUMBER",	},
+	{	SF_STR_DISCNUMBER,	"DISCNUMBER",	},
+	{	SF_STR_ALBUMARTIST,	"ALBUMARTIST",	},
+	{	SF_STR_PERFORMER,	"PERFORMER",	},
+	{	SF_STR_LABEL,		"LABEL",		},
+	{	SF_STR_ISRC,		"ISRC",			},
 	{	SF_STR_GENRE,		"GENRE",		},
 	{	0,					NULL,			},
 } ;

--- a/src/ogg_vorbis.c
+++ b/src/ogg_vorbis.c
@@ -121,6 +121,11 @@ static STR_PAIRS vorbis_metatypes [] =
 	{	SF_STR_ALBUM,		"Album" },
 	{	SF_STR_LICENSE,		"License" },
 	{	SF_STR_TRACKNUMBER,	"Tracknumber" },
+	{	SF_STR_DISCNUMBER,	"Discnumber" },
+	{	SF_STR_ALBUMARTIST,	"Albumartist" },
+	{	SF_STR_PERFORMER,	"Performer" },
+	{	SF_STR_LABEL,		"Label" },
+	{	SF_STR_ISRC,		"ISRC" },
 	{	SF_STR_GENRE,		"Genre" },
 } ;
 
@@ -350,6 +355,11 @@ vorbis_write_header (SF_PRIVATE *psf, int UNUSED (calc_length))
 			case SF_STR_ALBUM :			name = "ALBUM" ; break ;
 			case SF_STR_LICENSE :		name = "LICENSE" ; break ;
 			case SF_STR_TRACKNUMBER :	name = "Tracknumber" ; break ;
+			case SF_STR_DISCNUMBER :	name = "DISCNUMBER" ; break ;
+			case SF_STR_ALBUMARTIST :	name = "ALBUMARTIST" ; break ;
+			case SF_STR_PERFORMER :		name = "PERFORMER" ; break ;
+			case SF_STR_LABEL :			name = "LABEL" ; break ;
+			case SF_STR_ISRC :			name = "ISRC" ; break ;
 			case SF_STR_GENRE :			name = "Genre" ; break ;
 
 			default : continue ;

--- a/src/strings.c
+++ b/src/strings.c
@@ -114,6 +114,11 @@ psf_store_string (SF_PRIVATE *psf, int str_type, const char *str)
 		case SF_STR_ALBUM :
 		case SF_STR_LICENSE :
 		case SF_STR_TRACKNUMBER :
+		case SF_STR_DISCNUMBER :
+		case SF_STR_ALBUMARTIST :
+		case SF_STR_PERFORMER :
+		case SF_STR_LABEL :
+		case SF_STR_ISRC :
 		case SF_STR_GENRE :
 				break ;
 

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -1027,6 +1027,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 			case ISRC_MARKER :
 			case IAUT_MARKER :
 			case ITRK_MARKER :
+			case PRT1_MARKER :
 					bytesread += psf_binheader_readf (psf, "4", &chunk_size) ;
 					chunk_size += (chunk_size & 1) ;
 					if (chunk_size >= SIGNED_SIZEOF (buffer) || bytesread + chunk_size > chunk_length)
@@ -1126,6 +1127,9 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 			case ITRK_MARKER :
 					psf_store_string (psf, SF_STR_TRACKNUMBER, buffer) ;
 					break ;
+			case PRT1_MARKER :
+					psf_store_string (psf, SF_STR_DISCNUMBER, buffer) ;
+					break ;
 			} ;
 		} ;
 
@@ -1189,6 +1193,10 @@ wavlike_write_strings (SF_PRIVATE *psf, int location)
 
 			case SF_STR_TRACKNUMBER :
 				psf_binheader_writef (psf, "ms", BHWm (ITRK_MARKER), BHWs (psf->strings.storage + psf->strings.data [k].offset)) ;
+				break ;
+
+			case SF_STR_DISCNUMBER :
+				psf_binheader_writef (psf, "ms", BHWm (PRT1_MARKER), BHWs (psf->strings.storage + psf->strings.data [k].offset)) ;
 				break ;
 
 			default :

--- a/src/wavlike.h
+++ b/src/wavlike.h
@@ -55,6 +55,8 @@
 #define IAUT_MARKER		MAKE_MARKER ('I', 'A', 'U', 'T')
 #define ITRK_MARKER		MAKE_MARKER ('I', 'T', 'R', 'K')
 
+#define PRT1_MARKER		MAKE_MARKER ('P', 'R', 'T', '1')
+
 #define exif_MARKER		MAKE_MARKER ('e', 'x', 'i', 'f')
 #define ever_MARKER		MAKE_MARKER ('e', 'v', 'e', 'r')
 #define etim_MARKER		MAKE_MARKER ('e', 't', 'i', 'm')

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -213,6 +213,7 @@ static const char
 	long_artist	[]	= "The artist who kept on changing its name",
 	genre		[]	= "The genre",
 	trackno		[]	= "Track three",
+	discno		[]	= "2",
 	id3v1_genre	[]	= "Rock",
 	year		[]	= "2001" ;
 
@@ -410,6 +411,7 @@ string_start_test (const char *filename, int formattype)
 	sf_set_string (file, SF_STR_COMMENT, comment) ;
 	sf_set_string (file, SF_STR_ALBUM, album) ;
 	sf_set_string (file, SF_STR_LICENSE, license) ;
+	sf_set_string (file, SF_STR_DISCNUMBER, discno) ;
 	if (typemajor == SF_FORMAT_MPEG)
 	{	sf_set_string (file, SF_STR_GENRE, id3v1_genre) ;
 		sf_set_string (file, SF_STR_DATE, year) ;
@@ -515,6 +517,16 @@ string_start_test (const char *filename, int formattype)
 		{	if (errors++ == 0)
 				puts ("\n") ;
 			printf ("    Bad album     : %s\n", NULL_PRINTF_CHECK(cptr)) ;
+			} ;
+		} ;
+
+	if (typemajor != SF_FORMAT_CAF && typemajor != SF_FORMAT_AIFF)
+	{
+		cptr = sf_get_string (file, SF_STR_DISCNUMBER) ;
+		if (cptr == NULL || strcmp (discno, cptr) != 0)
+		{	if (errors++ == 0)
+				puts ("\n") ;
+			printf ("    Bad discno    : %s\n", NULL_PRINTF_CHECK(cptr)) ;
 			} ;
 		} ;
 
@@ -926,7 +938,7 @@ string_identity_test (const char *filename, int typemajor)
 		album,
 		NULL, /* license */
 		trackno,
-		"2", /* discnumber */
+		discno,
 		"Test album artist",
 		"Test performer",
 		"Test label",

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -18,6 +18,7 @@
 
 #include "sfconfig.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -48,10 +49,12 @@ static void	string_rdwr_test (const char *filename, int typemajor) ;
 static void	string_short_rdwr_test (const char *filename, int typemajor) ;
 static void	string_rdwr_grow_test (const char *filename, int typemajor) ;
 static void	string_header_update (const char *filename, int typemajor) ;
+static void	string_identity_test (const char *filename, int typemajor) ;
 
 static void	software_string_test (const char *filename) ;
 
 static int str_count (const char * haystack, const char * needle) ;
+static char *string_nullable_dup_or_die (const char *in) ;
 
 int
 main (int argc, char *argv [])
@@ -111,7 +114,9 @@ main (int argc, char *argv [])
 
 	if (do_all || ! strcmp (argv [1], "flac"))
 	{	if (HAVE_EXTERNAL_XIPH_LIBS)
-			string_start_test ("strings.flac", SF_FORMAT_FLAC) ;
+		{	string_start_test ("strings.flac", SF_FORMAT_FLAC) ;
+			string_identity_test ("strings.flac", SF_FORMAT_FLAC) ;
+			}
 		else
 			puts ("    No FLAC tests because FLAC support was not compiled in.") ;
 		test_count++ ;
@@ -905,3 +910,150 @@ string_header_update (const char *filename, int typemajor)
 	unlink (filename) ;
 	puts ("ok") ;
 } /* string_header_update */
+
+static void
+string_identity_test (const char *filename, int typemajor)
+{	char *strings_map [SF_STR_LAST - SF_STR_FIRST + 1] = { 0 } ;
+	char ok = 1 ;
+	char create_reference = 0 ; /* set this to 1 to generate the TEST_DATA */
+	const char *strings_write [] =
+	{	title,
+		NULL, /* copyright */
+		NULL, /* software */
+		artist,
+		NULL, /* comment */
+		date,
+		album,
+		NULL, /* license */
+		trackno,
+		"2", /* discnumber */
+		"Test album artist",
+		"Test performer",
+		"Test label",
+		NULL, /* ISRC */
+		NULL, /* 0x0f */
+		NULL, /* genre */
+		} ;
+	const char TEST_DATA [] =
+	{	0x66, 0x4c, 0x61, 0x43, 0x00, 0x00, 0x00, 0x22, 0x10, 0x00, 0x10,
+		0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x0e, 0x0a, 0xc4, 0x42, 0xf0,
+		0x00, 0x00, 0x02, 0x00, 0xc9, 0x9a, 0x74, 0xc5, 0x55, 0x37, 0x1a,
+		0x43, 0x3d, 0x12, 0x1f, 0x55, 0x1d, 0x6c, 0x63, 0x98, 0x84, 0x00,
+		0x00, 0xfa, 0x20, 0x00, 0x00, 0x00, 0x72, 0x65, 0x66, 0x65, 0x72,
+		0x65, 0x6e, 0x63, 0x65, 0x20, 0x6c, 0x69, 0x62, 0x46, 0x4c, 0x41,
+		0x43, 0x20, 0x31, 0x2e, 0x34, 0x2e, 0x32, 0x20, 0x32, 0x30, 0x32,
+		0x32, 0x31, 0x30, 0x32, 0x32, 0x09, 0x00, 0x00, 0x00, 0x17, 0x00,
+		0x00, 0x00, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x54, 0x68, 0x69,
+		0x73, 0x20, 0x69, 0x73, 0x20, 0x74, 0x68, 0x65, 0x20, 0x74, 0x69,
+		0x74, 0x6c, 0x65, 0x11, 0x00, 0x00, 0x00, 0x61, 0x72, 0x74, 0x69,
+		0x73, 0x74, 0x3d, 0x54, 0x68, 0x65, 0x20, 0x41, 0x72, 0x74, 0x69,
+		0x73, 0x74, 0x0f, 0x00, 0x00, 0x00, 0x64, 0x61, 0x74, 0x65, 0x3d,
+		0x32, 0x30, 0x30, 0x31, 0x2f, 0x30, 0x31, 0x2f, 0x32, 0x37, 0x0f,
+		0x00, 0x00, 0x00, 0x61, 0x6c, 0x62, 0x75, 0x6d, 0x3d, 0x54, 0x68,
+		0x65, 0x20, 0x41, 0x6c, 0x62, 0x75, 0x6d, 0x17, 0x00, 0x00, 0x00,
+		0x74, 0x72, 0x61, 0x63, 0x6b, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
+		0x3d, 0x54, 0x72, 0x61, 0x63, 0x6b, 0x20, 0x74, 0x68, 0x72, 0x65,
+		0x65, 0x0c, 0x00, 0x00, 0x00, 0x64, 0x69, 0x73, 0x63, 0x6e, 0x75,
+		0x6d, 0x62, 0x65, 0x72, 0x3d, 0x32, 0x1d, 0x00, 0x00, 0x00, 0x61,
+		0x6c, 0x62, 0x75, 0x6d, 0x61, 0x72, 0x74, 0x69, 0x73, 0x74, 0x3d,
+		0x54, 0x65, 0x73, 0x74, 0x20, 0x61, 0x6c, 0x62, 0x75, 0x6d, 0x20,
+		0x61, 0x72, 0x74, 0x69, 0x73, 0x74, 0x18, 0x00, 0x00, 0x00, 0x70,
+		0x65, 0x72, 0x66, 0x6f, 0x72, 0x6d, 0x65, 0x72, 0x3d, 0x54, 0x65,
+		0x73, 0x74, 0x20, 0x70, 0x65, 0x72, 0x66, 0x6f, 0x72, 0x6d, 0x65,
+		0x72, 0x10, 0x00, 0x00, 0x00, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x3d,
+		0x54, 0x65, 0x73, 0x74, 0x20, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0xff,
+		0xf8, 0x99, 0x18, 0x00, 0xe6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x9a, 0xaa
+		} ;
+
+	int i ;
+	SNDFILE *file ;
+	SF_INFO sfinfo ;
+
+	/* Right now it supports only FLAC */
+	if (typemajor != SF_FORMAT_FLAC)
+		return ;
+
+	get_unique_test_name (&filename, STR_TEST_PREFIX) ;
+	print_test_name (__func__, filename) ;
+
+	memset (&sfinfo, 0, sizeof (sfinfo)) ;
+
+	/* Create reference file */
+	if (create_reference)
+	{	assert (sizeof (strings_write) == sizeof (strings_map)) ;
+		sfinfo.samplerate	= 44100 ;
+		sfinfo.channels		= 2 ;
+		sfinfo.frames		= 441 ;
+		sfinfo.format		= typemajor | SF_FORMAT_PCM_16 ;
+
+		file = test_open_file_or_die (filename, SFM_WRITE, &sfinfo, SF_FALSE, __LINE__) ;
+		for (i = SF_STR_FIRST ; i <= SF_STR_LAST ; i++)
+			if (strings_write [i - SF_STR_FIRST] != NULL)
+				sf_set_string (file, i, strings_write [i - SF_STR_FIRST]) ;
+		test_write_short_or_die (file, 0, data_out, BUFFER_LEN, __LINE__) ;
+		sf_close (file) ;
+		hexdump_file (filename, 0, 9000) ;
+		check_file_hash_or_die (filename, 0x4f3b3b5c31e9b, __LINE__) ;
+		}
+	else
+	{	dump_data_to_file (filename, TEST_DATA, sizeof (TEST_DATA)) ;
+		} ;
+
+	/* Read file strings into RAM */
+	file = test_open_file_or_die (filename, SFM_READ, &sfinfo, SF_FALSE, __LINE__) ;
+	for (i = SF_STR_FIRST ; i <= SF_STR_LAST ; i++)
+		strings_map [i - SF_STR_FIRST] = string_nullable_dup_or_die (sf_get_string (file, i)) ;
+	sf_close (file) ;
+
+	/* Write file that is a copy */
+	file = test_open_file_or_die (filename, SFM_WRITE, &sfinfo, SF_FALSE, __LINE__) ;
+	for (i = SF_STR_FIRST ; i <= SF_STR_LAST ; i++)
+	{	char *value = strings_map [i - SF_STR_FIRST] ;
+		if (value != NULL)
+		{	sf_set_string (file, i, value) ;
+			free (value) ;
+			} ;
+		} ;
+	test_write_short_or_die (file, 0, data_out, BUFFER_LEN, __LINE__) ;
+	sf_close (file) ;
+
+	if (create_reference)
+	{	/* Copy must still identify the same strings */
+		file = test_open_file_or_die (filename, SFM_READ, &sfinfo, SF_FALSE, __LINE__) ;
+		for (i = SF_STR_FIRST ; i <= SF_STR_LAST ; i++)
+		{	const char *assoc_val = sf_get_string (file, i) ;
+			if (strings_write [i - SF_STR_FIRST] != NULL)
+			{	if (assoc_val == NULL)
+				{	fprintf (stderr, "\n\nLine %d: No value for %d, expected %s\n", __LINE__, i, strings_write [i - SF_STR_FIRST]) ;
+					ok = 0 ;
+					}
+				else if (strcmp (assoc_val, strings_write [i - SF_STR_FIRST]) != 0)
+				{	fprintf (stderr, "\n\nLine %d: Mismatch, got %s, expected %s\n", __LINE__, assoc_val, strings_write [i - SF_STR_FIRST]) ;
+					} ;
+				} ;
+			} ;
+		sf_close (file) ;
+		}
+	else
+	{	/* Re-written file equals test data! */
+		check_file_hash_or_die (filename, 0x4f3b3b5c31e9b, __LINE__) ;
+		unlink (filename) ;
+		} ;
+
+	if (ok)
+		puts ("ok") ;
+}
+
+static char
+*string_nullable_dup_or_die (const char *in)
+{	size_t string_size ;
+	char *cpy ;
+	if (in == NULL)
+		return NULL ;
+	string_size = strlen (in) + 1 ;
+	cpy = malloc (string_size) ;
+	assert (cpy != NULL) ;
+	memcpy (cpy, in, string_size) ;
+	return cpy ;
+}


### PR DESCRIPTION
Hello libsndfile team,

in #982, the topic regarding the limited choice of strings that can be processed by libsndfile was raised. I came across this while trying to find out why the sort order in MPD was different between a resampled and the original file and it turns out that metadata was lost in the conversion process which in turn seems to be caused by an API limitation in libsndfile.

I don't know if it is possible to solve this in a generic way but in the meantime, it would help for my use case if more metadata fields could be supported. The most important one from my point of view is DISCNUMBER. I tried to find out what other strings could be sensible to add and have prepared a draft PR for the purpose.

Please have a look and see if it makes sense to go about it this way?

The original issue from #982 which is wrt. the inclusion of images inside the sound file remains unresolved even by these commits. I would like to have that feature, too, but couldn't come up with a solution just yet.

Also, i wonder about the following things:

 * Why are there two tables for vorbis comments (ogg_vcomment.c:vorbiscomment_mapping and ogg_vorbis.c:vorbis_write_header). Would it make sense to merge them together by extracting a common file or something of that sorts?
 * Why are FLAC strings in lowercase (like e.g. "tracknumber")? `metaflac` produces them in all-caps?
 * What do you think about the encoding of a “reference file” inside the test data (5b4b32e2e5d5afccde7d0e9faf3ba90e0dc4122b). Does it make sense or is such a test too fragile?

Thanks in advance and kind regards,
Linux-Fan (@m7a)