### PR TITLE
Unseekable Steams Support (pipes) for Virtual IOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Unseekable steams support (pipes) for Virtual IOs
+
+  If your stream is not seekable, set "seek", "get_filelen", and "tell" callbacks
+  to NULL in SF_VIRTUAL_IO. In this case, the library will treat your stream as
+  a non-seekable virtual pipe. Note that not all operations are available for pipes.
+  For example you can open a WAV file for read but it's impossible to write WAV file
+  to a pipe because the WAV format requires a length of file to be written at beginning
+  of the file which is impossible without supporting of "seek".
+
 ### Fixed
 
 * Disable autogen rules when autogen cannot be found

--- a/docs/api.md
+++ b/docs/api.md
@@ -256,6 +256,14 @@ typedef sf_count_t  (*sf_vio_write)       (const void *ptr, sf_count_t count, vo
 typedef sf_count_t  (*sf_vio_tell)        (void *user_data) ;
 ```
 
+Note that not all callbacks are required. If your stream is not seekable, set
+"seek", "get_filelen", and "tell" callbacks to NULL. In this case, the library
+will treat your stream as a non-seekable virtual pipe. Note that not all operations
+are available for pipes. For example you can open a WAV file for read but it's
+impossible to write WAV file to a pipe because the WAV format requires a length
+of file to be written at beginning of the file which is impossible without
+supporting of "seek".
+
 #### sf_vio_get_filelen
 
 ```c
@@ -263,6 +271,8 @@ typedef sf_count_t  (*sf_vio_get_filelen) (void *user_data) ;
 ```
 
 The virtual file context must return the length of the virtual file in bytes.
+This callback may be set to NULL in case "seek" is NULL. See description for
+the "sf_vio_seek" callback.
 
 #### sf_vio_seek
 
@@ -274,6 +284,9 @@ The virtual file context must seek to offset using the seek mode provided by
 whence which is one of SEEK_CUR, SEEK_SET, SEEK_END.
 
 The return value must contain the new offset in the file.
+If this callback is set to NULL, the library will treat your stream as
+a non-seekable virtual pipe. If so, the library will not use "tell" and
+"get_filelen" callbacks so they can be set to NULL as well.
 
 #### sf_vio_read
 
@@ -292,6 +305,7 @@ typedef sf_count_t  (*sf_vio_write)       (const void *ptr, sf_count_t count, vo
 
 The virtual file context must process "count" bytes stored in the buffer passed
 with ptr and return the count of actually processed bytes.
+This callback is only required when "mode" is either SFM_WRITE or SFM_RDWR.
 
 #### sf_vio_tell
 
@@ -300,6 +314,8 @@ typedef sf_count_t  (*sf_vio_tell)        (void *user_data) ;
 ```
 
 Return the current position of the virtual file context.
+This callback may be set to NULL in case "seek" is NULL. See description for
+the "sf_vio_seek" callback.
 
 ## Format Check Function {#chek}
 

--- a/src/common.c
+++ b/src/common.c
@@ -1560,7 +1560,7 @@ psf_decode_frame_count (SF_PRIVATE *psf)
 	BUF_UNION	ubuf ;
 
 	/* If we're reading from a pipe or the file is too long, just return SF_COUNT_MAX. */
-	if (psf_is_pipe (psf) || psf->datalength > 0x1000000)
+	if (psf->is_pipe || psf->datalength > 0x1000000)
 		return SF_COUNT_MAX ;
 
 	psf_fseek (psf, psf->dataoffset, SEEK_SET) ;

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -472,17 +472,21 @@ SNDFILE*
 sf_open_virtual	(SF_VIRTUAL_IO *sfvirtual, int mode, SF_INFO *sfinfo, void *user_data)
 {	SF_PRIVATE 	*psf ;
 
-	/* Make sure we have a valid set of virtual pointers. */
-	if (sfvirtual->get_filelen == NULL)
-	{	sf_errno = SFE_BAD_VIRTUAL_IO ;
-		snprintf (sf_parselog, sizeof (sf_parselog), "Bad vio_get_filelen in SF_VIRTUAL_IO struct.\n") ;
-		return NULL ;
-		} ;
+	if (sfvirtual->seek != NULL)
+	{
+		/* Make sure we have a valid set of virtual pointers. */
+		if (sfvirtual->get_filelen == NULL)
+		{	sf_errno = SFE_BAD_VIRTUAL_IO ;
+			snprintf (sf_parselog, sizeof (sf_parselog), "Bad vio_get_filelen in SF_VIRTUAL_IO struct.\n") ;
+			return NULL ;
+			} ;
 
-	if ((sfvirtual->seek == NULL || sfvirtual->tell == NULL) && sfinfo->seekable)
-	{	sf_errno = SFE_BAD_VIRTUAL_IO ;
-		snprintf (sf_parselog, sizeof (sf_parselog), "Bad vio_seek / vio_tell in SF_VIRTUAL_IO struct.\n") ;
-		return NULL ;
+		if (sfvirtual->tell == NULL)
+		{	sf_errno = SFE_BAD_VIRTUAL_IO ;
+			snprintf (sf_parselog, sizeof (sf_parselog), "Bad vio_tell in SF_VIRTUAL_IO struct.\n") ;
+			return NULL ;
+			} ;
+
 		} ;
 
 	if ((mode == SFM_READ || mode == SFM_RDWR) && sfvirtual->read == NULL)


### PR DESCRIPTION
If your stream is not seekable, set "seek", "get_filelen", and "tell" callbacks to NULL in SF_VIRTUAL_IO. In this case, the library will treat your stream as a non-seekable virtual pipe. Note that not all operations are available for pipes. For example you can open a WAV file for read but it's impossible to write WAV file to a pipe because the WAV format requires a length of file to be written at beginning of the file which is impossible without supporting of "seek".