### PR TITLE
Include <stdbool.h> instead of redefining `bool`, `true` and `false` keywords

### DIFF
--- a/src/ALAC/alac_decoder.c
+++ b/src/ALAC/alac_decoder.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "alac_codec.h"
@@ -39,11 +40,6 @@
 
 #include "ALACBitUtilities.h"
 #include "EndianPortable.h"
-
-typedef enum
-{	false = 0,
-	true = 1
-} bool ;
 
 // constants/data
 const uint32_t kMaxBitDepth = 32 ;			// max allowed bit depth is 32

--- a/src/ALAC/alac_encoder.c
+++ b/src/ALAC/alac_encoder.c
@@ -32,6 +32,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "sfendian.h"
@@ -45,12 +46,6 @@
 #include "ALACBitUtilities.h"
 #include "ALACAudioTypes.h"
 #include "EndianPortable.h"
-
-typedef enum
-{
-	false = 0,
-	true = 1
-} bool ;
 
 static void	GetConfig (ALAC_ENCODER *p, ALACSpecificConfig * config) ;
 


### PR DESCRIPTION
Fixes #1049