### PR TITLE
1060 add sf get format check failure reason

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,7 @@ documented) [here](command.md).**
 | [sf_open_fd](#open_fd)                                                                                      | Open sound file using file descriptor.         |
 | [sf_open_virtual](#open_virtual)                                                                            | Open sound file using virtual API.             |
 | [sf_format_check](#check)                                                                                   | Validate sound file info.                      |
+| [sf_get_format_check_failure_reason](#checkfr)                                                              | Validate sound file info or return error str.  |
 | [sf_seek](#seek)                                                                                            | Seek position in sound file.                   |
 | [sf_command](command.md)                                                                                    | Command interface.                             |
 | [sf_error, sf_strerror, sf_error_number, sf_perror, sf_error_str](#error)                                   | Error functions.                               |
@@ -301,7 +302,7 @@ typedef sf_count_t  (*sf_vio_tell)        (void *user_data) ;
 
 Return the current position of the virtual file context.
 
-## Format Check Function {#chek}
+## Format Check Function {#check}
 
 ```c
 int  sf_format_check (const SF_INFO *info) ;
@@ -310,7 +311,22 @@ int  sf_format_check (const SF_INFO *info) ;
 This function allows the caller to check if a set of parameters in the SF_INFO
 struct is valid before calling [sf_open](#open) (SFM_WRITE).
 
-sf_format_check() returns TRUE if the parameters are valid and FALSE otherwise.
+sf_format_check() returns TRUE if the parameters are valid or FALSE otherwise.
+
+## Get Format Check Failure Reason Function {#checkfr}
+
+```c
+const char *  sf_get_format_check_failure_reason (const SF_INFO *info) ;
+```
+
+This function allows the caller to check if a set of parameters in the SF_INFO
+struct is valid before calling [sf_open](#open) (SFM_WRITE).
+
+sf_format_check() returns NULL if the parameters are valid or a pointer
+to a human-readable NUL-terminated string describing the problem otherwise.
+
+This function is logically equivalent to sf_format_check(), but with
+a different return type.
 
 ## File Seek Functions
 

--- a/include/sndfile.h
+++ b/include/sndfile.h
@@ -650,9 +650,22 @@ int		sf_error_str	(SNDFILE *sndfile, char* str, size_t len) ;
 int		sf_command	(SNDFILE *sndfile, int command, void *data, int datasize) ;
 
 
-/* Return TRUE if fields of the SF_INFO struct are a valid combination of values. */
+/* Return SF_TRUE if fields of the SF_INFO struct are a valid combination of values,
+ * of SF_FALSE if they cannot be used.
+** Note this function is logically equivalent to:
+**    return (sf_get_format_check_failure_reason(info) == NULL) ? SF_TRUE : SF_FALSE;
+*/
 
 int		sf_format_check	(const SF_INFO *info) ;
+
+
+/* Return NULL if fields of the SF_INFO struct are a valid combination of values,
+** or a human-readable explanation-string describing the problem otherwise.
+** Note that this function is logically equivalent to sf_format_check(), just with
+** a different return-type.
+*/
+
+const char *		sf_get_format_check_failure_reason (const SF_INFO *info) ;
 
 
 /* Seek within the waveform data chunk of the SNDFILE. sf_seek () uses

--- a/include/sndfile.hh
+++ b/include/sndfile.hh
@@ -132,6 +132,7 @@ class SndfileHandle
 		const char* getString (int str_type) const ;
 
 		static int formatCheck (int format, int channels, int samplerate) ;
+		static const char * getFormatCheckFailureReason (int format, int channels, int samplerate) ;
 
 		sf_count_t read (short *ptr, sf_count_t items) ;
 		sf_count_t read (int *ptr, sf_count_t items) ;
@@ -363,6 +364,22 @@ SndfileHandle::formatCheck (int fmt, int chans, int srate)
 
 	return sf_format_check (&sfinfo) ;
 }
+
+inline const char  *
+SndfileHandle::getFormatCheckFailureReason (int fmt, int chans, int srate)
+{
+	SF_INFO sfinfo ;
+
+	sfinfo.frames = 0 ;
+	sfinfo.channels = chans ;
+	sfinfo.format = fmt ;
+	sfinfo.samplerate = srate ;
+	sfinfo.sections = 0 ;
+	sfinfo.seekable = 0 ;
+
+	return sf_get_format_check_failure_reason (&sfinfo) ;
+}
+
 
 /*---------------------------------------------------------------------*/
 

--- a/programs/sndfile-convert.c
+++ b/programs/sndfile-convert.c
@@ -104,29 +104,12 @@ usage_exit (const char *progname)
 } /* usage_exit */
 
 static void
-report_format_error_exit (const char * argv0, SF_INFO * sfinfo)
-{	int old_format = sfinfo->format ;
-	int endian = sfinfo->format & SF_FORMAT_ENDMASK ;
-	int channels = sfinfo->channels ;
-
-	sfinfo->format = old_format & (SF_FORMAT_TYPEMASK | SF_FORMAT_SUBMASK) ;
-
-	if (endian && sf_format_check (sfinfo))
-	{	printf ("Error : output file format does not support %s endian-ness.\n", sfe_endian_name (endian)) ;
-		exit (1) ;
-		} ;
-
-	sfinfo->channels = 1 ;
-	if (sf_format_check (sfinfo))
-	{	printf ("Error : output file format does not support %d channels.\n", channels) ;
-		exit (1) ;
-		} ;
-
+report_format_error_exit (const char * argv0, const SF_INFO * sfinfo)
+{
 	printf ("\n"
-			"Error : output file format is invalid.\n"
-			"The '%s' container does not support '%s' codec data.\n"
+			"Error : output file format is invalid (%s).\n"
 			"Run '%s --help' for clues.\n\n",
-			sfe_container_name (sfinfo->format), sfe_codec_name (sfinfo->format), program_name (argv0)) ;
+			sf_get_format_check_failure_reason(sfinfo), program_name (argv0)) ;
 	exit (1) ;
 } /* report_format_error_exit */
 

--- a/src/create_symbols_file.py
+++ b/src/create_symbols_file.py
@@ -80,6 +80,7 @@ ALL_SYMBOLS = (
 	(	"sf_get_chunk_iterator",	103 ),
 	(	"sf_next_chunk_iterator",	104 ),
 	(	"sf_current_byterate",	110 )
+	(	"sf_get_format_check_failure_reason", 111 ),
 	)
 
 #-------------------------------------------------------------------------------

--- a/src/create_symbols_file.py
+++ b/src/create_symbols_file.py
@@ -79,7 +79,7 @@ ALL_SYMBOLS = (
 	(	"sf_get_chunk_data",	102 ),
 	(	"sf_get_chunk_iterator",	103 ),
 	(	"sf_next_chunk_iterator",	104 ),
-	(	"sf_current_byterate",	110 )
+	(	"sf_current_byterate",	110 ),
 	(	"sf_get_format_check_failure_reason", 111 ),
 	)
 

--- a/tests/command_test.c
+++ b/tests/command_test.c
@@ -492,7 +492,7 @@ format_tests	(void)
 		sfinfo.format = format_info.format ;
 
 		if (! sf_format_check (&sfinfo))
-		{	printf ("\n\nLine %d: sf_format_check failed.\n", __LINE__) ;
+		{	printf ("\n\nLine %d: sf_format_check failed, because [%s]\n", __LINE__, sf_get_format_check_failure_reason(&sfinfo) ) ;
 			printf ("        Name : %s\n", format_info.name) ;
 			printf ("        Format      : 0x%X\n", sfinfo.format) ;
 			printf ("        Channels    : 0x%X\n", sfinfo.channels) ;

--- a/tests/utils.tpl
+++ b/tests/utils.tpl
@@ -528,7 +528,7 @@ test_sf_format_or_die (const SF_INFO *info, int line_num)
 {	int res ;
 
 	if ((res = sf_format_check (info)) != 1)
-	{	printf ("\n\nLine %d : sf_format_check returned error (%d)\n\n", line_num, res) ;
+	{	printf ("\n\nLine %d : sf_format_check returned error (%d) (%s)\n\n", line_num, res, sf_get_format_check_failure_reason (info)) ;
 		exit (1) ;
 		} ;
 


### PR DESCRIPTION
Issue #1060: Add sf_get_format_check_failure_reason()

This is a candidate implementation for GitHub issue #1060 -- it adds
a new function to the libsndfile API:

   const char * sf_get_format_check_failure_reason(const SF_INFO *);

This function is logically equivalent to the existing sf_format_check()
function, except that instead of returning SF_TRUE on success and SF_FALSE
on failure, it returns NULL on success and a human-readable explanation
string on failure, so that the nature of the format-incompatibility can
be made more readily-apparent to the developer or the user.

Replaced the existing sf_format_check() implementation with a one-line
wrapper around this function to avoid code-duplication.