### PR TITLE
Update build for using cmake 4, fixing issue #1076

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12...3.26)
+cmake_minimum_required (VERSION 3.5...4.0)
 
 # MSVC runtime library flags are selected by an abstraction, CMake >= 3.15
 # This policy still need to be set even with cmake_minimum_required() command above.
@@ -483,7 +483,7 @@ if (BUILD_SHARED_LIBS)
 	if (DEFINED SYMBOL_OS)
 		add_custom_command (
 			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/${SYMBOL_FILENAME}
-			COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/create_symbols_file.py ${SYMBOL_OS} ${SNDFILE_ABI_VERSION} > ${CMAKE_CURRENT_BINARY_DIR}/src/${SYMBOL_FILENAME}
+			COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/create_symbols_file.py ${SYMBOL_OS} ${SNDFILE_ABI_VERSION} > ${CMAKE_CURRENT_BINARY_DIR}/src/${SYMBOL_FILENAME}
 			COMMENT "Generating ${SYMBOL_FILENAME}..."
 			)
 

--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -249,5 +249,5 @@ if (DEFINED ENABLE_STATIC_RUNTIME)
 endif ()
 
 if (BUILD_SHARED_LIBS)
-	find_package (PythonInterp REQUIRED)
+	find_package (Python REQUIRED)
 endif()


### PR DESCRIPTION
This allows building libsndfile using cmake 4.0. See issue #1076
Changes cmake_minimum_required minimum to 3.5, since  cmake 4.0 will not accept earlier versions
Changes cmake_minimum_required maximum to 4.0
Changes use of obsoleted package PythonInterp to Python which is current and is backwards compatible with older versions of cmake

Tested by building libsndfile via homebrew on macOS 13.7.5