### PR TITLE
fix opus inclusion

### DIFF
--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -162,8 +162,8 @@
 #if HAVE_EXTERNAL_XIPH_LIBS
 
 #include <ogg/ogg.h>
-#include <opus/opus.h>
-#include <opus/opus_multistream.h>
+#include <opus.h>
+#include <opus_multistream.h>
 
 #include "ogg.h"
 #include "ogg_vcomment.h"


### PR DESCRIPTION
The pkgconfig file for Opus includes the opus subdirectory, not the raw include directory.