### PR TITLE
Prevent linker warning about duplicate libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,8 +386,7 @@ target_include_directories (sndfile
 	)
 target_link_libraries (sndfile
 	PRIVATE
-		$<$<BOOL:${LIBM_REQUIRED}>:m>
-		$<$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>:Ogg::ogg>
+		$<$<AND:${LIBM_REQUIRED},$<NOT:$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>>>:m>
 		$<$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>:Vorbis::vorbisenc>
 		$<$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>:FLAC::FLAC>
 		$<$<AND:$<BOOL:${ENABLE_EXPERIMENTAL}>,$<BOOL:${HAVE_EXTERNAL_XIPH_LIBS}>,$<BOOL:${HAVE_SPEEX}>>:Speex::Speex>


### PR DESCRIPTION
If vorbisenc is included by sndfile, it already provides libm and ogg (which causes a linker warning)