### PR TITLE
Fix mp3 write short stereo

### DIFF
--- a/src/mpeg_l3_encode.c
+++ b/src/mpeg_l3_encode.c
@@ -508,7 +508,7 @@ mpeg_l3_encode_write_short_stereo (SF_PRIVATE *psf, const short *ptr, sf_count_t
 		 * An oversight, but lame_encode_buffer_interleaved() lacks a const.
 		 * As such, need another memcpy to not cause a warning.
 		 */
-		memcpy (ubuf.sbuf, ptr + total, writecount) ;
+		memcpy (ubuf.sbuf, ptr + total, writecount * 2) ;
 		nbytes = lame_encode_buffer_interleaved (pmpeg->lamef, ubuf.sbuf, writecount / 2, pmpeg->block, pmpeg->block_len) ;
 		if (nbytes < 0)
 		{	psf_log_printf (psf, "lame_encode_buffer returned %d\n", nbytes) ;


### PR DESCRIPTION
mpeg_l3_encode_write_short_stereo has a bug that makes it completely unusable. This can be demoed by modifying sndfile-convert.c to use sf_write_short instead of sf_write_float for mp3, then try to convert a file from any format (say PCM_S16) to mp3. The file will play, but half of the data is replaced by noise.

The issue and its fix are very straightforward. In `mpeg_l3_encode.c` function `mpeg_l3_encode_write_short_stereo` there is an existing workaround for " An oversight, but lame_encode_buffer_interleaved() lacks a const." That code is:
```
memcpy (ubuf.sbuf, ptr + total, writecount) ;
```
`writecount` is a measure of number of samples, while `memcpy` is expecting a number of bytes. So that needs to be:
```
memcopy(ubuf.sbuf, ptr + total, writecount * 2) ;
```
