### PR TITLE
ima_adpcm: complete int overflow fix for WAV and close paths

### DIFF
--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -164,7 +164,7 @@ ima_close	(SF_PRIVATE *psf)
 		if (pima->samplecount && pima->samplecount < pima->samplesperblock)
 			pima->encode_block (psf, pima) ;
 
-		psf->sf.frames = pima->samplesperblock * pima->blockcount / psf->sf.channels ;
+		psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blockcount / psf->sf.channels ;
 		} ;
 
 	return 0 ;
@@ -232,7 +232,7 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 
 				pima->decode_block = wavlike_ima_decode_block ;
 
-				psf->sf.frames = pima->samplesperblock * pima->blocks ;
+				psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blocks ;
 				break ;
 
 		case SF_FORMAT_AIFF :


### PR DESCRIPTION
Fixes #1120
Commit 9a82911 ("fix int overflow in ima_reader_init()") cast samplesperblock to sf_count_t in the AIFF branch but not in the adjacent WAV branch or in ima_close. Both sites still compute int*int before assignment to psf->sf.frames and overflow on attacker-controlled WAV header values, leading to heap buffer overflow during decode.