### PR TITLE
Fix residual C23 bool/false keyword conflict in alac_decoder.h

### DIFF
--- a/src/ALAC/alac_decoder.h
+++ b/src/ALAC/alac_decoder.h
@@ -29,11 +29,9 @@
 
 #include "ALACAudioTypes.h"
 
-typedef enum
-{
-	false = 0,
-	ALAC_TRUE = 1
-} bool ;
+#include <stdbool.h>
+
+#define ALAC_TRUE true
 
 struct BitBuffer ;
 


### PR DESCRIPTION
## Summary

This fixes a residual C23 compatibility issue in `src/ALAC/alac_decoder.h` that was missed by PR #1055.

## Problem

The header `alac_decoder.h` defines a manual `bool` type using enum constants `false` and `ALAC_TRUE`. Under C23 (GCC 15 default), `bool`, `true`, and `false` are reserved keywords and cannot be used as enum constants or typedef names.

While this header is not currently included by any source file (the actual code uses `alac_codec.h`), the file still exists in the tree and would cause compilation failures if included under C23.

## Fix

Replace:
```c
typedef enum
{
    false = 0,
    ALAC_TRUE = 1
} bool ;
```

With:
```c
#include <stdbool.h>

#define ALAC_TRUE true
```

This mirrors the approach used in PR #1055 for the `.c` files.

## Verification

- The pattern compiles cleanly under `-std=gnu2x` (C23 draft mode)
- No other instances of `false` as enum constants or manual `bool` typedefs remain in the codebase

Fixes: #1049