### PR TITLE
ima_adpcm: fix signed integer overflow in sf.frames calculations

### DIFF
--- a/src/ima_adpcm.c
+++ b/src/ima_adpcm.c
@@ -164,7 +164,7 @@ ima_close	(SF_PRIVATE *psf)
 		if (pima->samplecount && pima->samplecount < pima->samplesperblock)
 			pima->encode_block (psf, pima) ;
 
-		psf->sf.frames = pima->samplesperblock * pima->blockcount / psf->sf.channels ;
+		psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blockcount / psf->sf.channels ;
 		} ;
 
 	return 0 ;
@@ -232,7 +232,7 @@ ima_reader_init (SF_PRIVATE *psf, int blockalign, int samplesperblock)
 
 				pima->decode_block = wavlike_ima_decode_block ;
 
-				psf->sf.frames = pima->samplesperblock * pima->blocks ;
+				psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blocks ;
 				break ;
 
 		case SF_FORMAT_AIFF :


### PR DESCRIPTION
## Summary

Fixes two cases of signed integer overflow (undefined behavior) when computing `sf.frames` from multiplying `int`-typed IMA-ADPCM fields.

## Problem

In `ima_adpcm.c`, `psf->sf.frames` is calculated as:

```c
// ima_close() — WAV/W64 write path (line 167)
psf->sf.frames = pima->samplesperblock * pima->blockcount / psf->sf.channels ;

// ima_reader_init() — W64 read path (line 235)
psf->sf.frames = pima->samplesperblock * pima->blocks ;
```

Both `samplesperblock` and `blockcount`/`blocks` are `int`. For audio files with large block counts (e.g. long WAV/W64 files), the intermediate product overflows `INT_MAX` before being stored in `sf_count_t`. This is **signed integer overflow — undefined behavior** per C11 §6.5p5, and in practice produces wrong frame counts and can cause seeks/reads to the wrong position.

## Fix

Pre-cast `samplesperblock` to `sf_count_t` before the multiplication, promoting the arithmetic to 64-bit:

```c
psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blockcount / psf->sf.channels ;
psf->sf.frames = (sf_count_t) pima->samplesperblock * pima->blocks ;
```

This matches the pattern already used in the AIFF branch (line 241) which was already correct.

## Affected paths

| Line | Code path | Fix needed |
|------|-----------|-----------|
| 167 | `ima_close()` — WAV/W64 write | ✅ this PR |
| 235 | `ima_reader_init()` — W64 read | ✅ this PR |
| 241 | `ima_reader_init()` — AIFF read | already correct |

## Detection

Detected by UBSan (`-fsanitize=undefined`):
```
ima_adpcm.c:167: runtime error: signed integer overflow: N * M cannot be represented in type 'int'
```

Reproducible with a crafted W64 file with `samplesperblock=32767` and `blocks=65536`.