### PR TITLE
fix: extend blockwidth integer overflow fix to remaining 20 format handlers

### DIFF
--- a/src/au.c
+++ b/src/au.c
@@ -131,7 +131,7 @@ au_open	(SF_PRIVATE *psf)
 
 	psf->container_close = au_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_ULAW :	/* 8-bit Ulaw encoding. */
@@ -446,7 +446,7 @@ au_read_header (SF_PRIVATE *psf)
 
 	psf_log_printf (psf, "  Channels    : %d\n", au_fmt.channels) ;
 
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 	if (! psf->sf.frames && psf->blockwidth)
 		psf->sf.frames = (psf->filelength - psf->dataoffset) / psf->blockwidth ;

--- a/src/avr.c
+++ b/src/avr.c
@@ -97,7 +97,7 @@ avr_open	(SF_PRIVATE *psf)
 
 	psf->container_close = avr_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	error = pcm_init (psf) ;
 
@@ -170,7 +170,7 @@ avr_read_header (SF_PRIVATE *psf)
 	if (psf_ftell (psf) != psf->dataoffset)
 		psf_binheader_readf (psf, "j", psf->dataoffset - psf_ftell (psf)) ;
 
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 	if (psf->sf.frames == 0 && psf->blockwidth)
 		psf->sf.frames = (psf->filelength - psf->dataoffset) / psf->blockwidth ;
@@ -195,7 +195,7 @@ avr_write_header (SF_PRIVATE *psf, int calc_length)
 		if (psf->dataend)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
-		psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+		psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	/* Reset the current header length to zero. */

--- a/src/caf.c
+++ b/src/caf.c
@@ -138,7 +138,7 @@ caf_open (SF_PRIVATE *psf)
 		if (format != SF_FORMAT_CAF)
 			return	SFE_BAD_OPEN_FORMAT ;
 
-		psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+		psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 		if (psf->file.mode != SFM_RDWR || psf->filelength < 44)
 		{	psf->filelength = 0 ;
@@ -600,7 +600,7 @@ caf_write_header (SF_PRIVATE *psf, int calc_length)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
 		if (psf->bytewidth > 0)
-			psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+			psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	/* Reset the current header length to zero. */

--- a/src/htk.c
+++ b/src/htk.c
@@ -76,7 +76,7 @@ htk_open	(SF_PRIVATE *psf)
 
 	psf->container_close = htk_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_PCM_16 :	/* 16-bit linear PCM. */
@@ -216,7 +216,7 @@ htk_read_header (SF_PRIVATE *psf)
 
 	psf->datalength = psf->filelength - psf->dataoffset ;
 
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 	if (! psf->sf.frames && psf->blockwidth)
 		psf->sf.frames = (psf->filelength - psf->dataoffset) / psf->blockwidth ;

--- a/src/mpc2k.c
+++ b/src/mpc2k.c
@@ -80,7 +80,7 @@ mpc2k_open	(SF_PRIVATE *psf)
 
 	psf->container_close = mpc2k_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	error = pcm_init (psf) ;
 
@@ -115,7 +115,7 @@ mpc2k_write_header (SF_PRIVATE *psf, int calc_length)
 		psf->dataoffset = HEADER_LENGTH ;
 		psf->datalength = psf->filelength - psf->dataoffset ;
 
-		psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+		psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	/* Reset the current header length to zero. */
@@ -192,7 +192,7 @@ mpc2k_read_header (SF_PRIVATE *psf)
 	psf->endian = SF_ENDIAN_LITTLE ;
 
 	psf->datalength = psf->filelength - psf->dataoffset ;
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 	psf->sf.frames = psf->datalength / psf->blockwidth ;
 
 	psf->sf.frames = (psf->filelength - psf->dataoffset) / psf->blockwidth ;

--- a/src/nist.c
+++ b/src/nist.c
@@ -70,7 +70,7 @@ nist_open	(SF_PRIVATE *psf)
 		if (psf->endian == 0 || psf->endian == SF_ENDIAN_CPU)
 			psf->endian = (CPU_IS_BIG_ENDIAN) ? SF_ENDIAN_BIG : SF_ENDIAN_LITTLE ;
 
-		psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+		psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 		psf->sf.frames = 0 ;
 
 		if ((error = nist_write_header (psf, SF_FALSE)))
@@ -224,7 +224,7 @@ nist_read_header (SF_PRIVATE *psf)
 		return SFE_NIST_BAD_ENCODING ;
 		} ;
 
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 	psf->datalength = psf->filelength - psf->dataoffset ;
 
 	psf_fseek (psf, psf->dataoffset, SEEK_SET) ;
@@ -300,7 +300,7 @@ nist_write_header (SF_PRIVATE *psf, int calc_length)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
 		if (psf->bytewidth > 0)
-			psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+			psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	if (psf->endian == SF_ENDIAN_BIG)

--- a/src/ogg_pcm.c
+++ b/src/ogg_pcm.c
@@ -107,7 +107,7 @@ ogg_pcm_open (SF_PRIVATE *psf)
 		} ;
 
 	psf->bytewidth = 1 ;
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 #if 0
 	psf->seek = opcm_seek ;

--- a/src/ogg_speex.c
+++ b/src/ogg_speex.c
@@ -123,7 +123,7 @@ ogg_speex_open (SF_PRIVATE *psf)
 		} ;
 
 	psf->bytewidth = 1 ;
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 #if 0
 	psf->seek = spx_seek ;

--- a/src/paf.c
+++ b/src/paf.c
@@ -223,7 +223,7 @@ paf_read_header	(SF_PRIVATE *psf)
 
 					psf->sf.format |= SF_FORMAT_PCM_S8 ;
 
-					psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+					psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 					psf->sf.frames = psf->datalength / psf->blockwidth ;
 					break ;
 
@@ -233,7 +233,7 @@ paf_read_header	(SF_PRIVATE *psf)
 
 					psf->sf.format |= SF_FORMAT_PCM_16 ;
 
-					psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+					psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 					psf->sf.frames = psf->datalength / psf->blockwidth ;
 					break ;
 

--- a/src/pvf.c
+++ b/src/pvf.c
@@ -72,7 +72,7 @@ pvf_open	(SF_PRIVATE *psf)
 
 	psf->container_close = pvf_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_PCM_S8 :	/* 8-bit linear PCM. */
@@ -179,7 +179,7 @@ pvf_read_header (SF_PRIVATE *psf)
 	psf->endian = SF_ENDIAN_BIG ;
 
 	psf->datalength = psf->filelength - psf->dataoffset ;
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 	if (! psf->sf.frames && psf->blockwidth)
 		psf->sf.frames = (psf->filelength - psf->dataoffset) / psf->blockwidth ;

--- a/src/raw.c
+++ b/src/raw.c
@@ -40,7 +40,7 @@ raw_open	(SF_PRIVATE *psf)
 	else if (CPU_IS_LITTLE_ENDIAN && (psf->endian == 0 || psf->endian == SF_ENDIAN_CPU))
 		psf->endian = SF_ENDIAN_LITTLE ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 	psf->dataoffset = 0 ;
 	psf->datalength = psf->filelength ;
 

--- a/src/rf64.c
+++ b/src/rf64.c
@@ -116,7 +116,7 @@ rf64_open (SF_PRIVATE *psf)
 	{	if (psf->is_pipe)
 			return SFE_NO_PIPE_WRITE ;
 
-		psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+		psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 		if ((error = rf64_write_header (psf, SF_FALSE)))
 			return error ;
@@ -655,7 +655,7 @@ rf64_write_header (SF_PRIVATE *psf, int calc_length)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
 		if (psf->bytewidth > 0)
-			psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+			psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	/* Reset the current header length to zero. */

--- a/src/sd2.c
+++ b/src/sd2.c
@@ -143,7 +143,7 @@ sd2_open (SF_PRIVATE *psf)
 
 	psf->container_close = sd2_close ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_PCM_S8 :	/* 8-bit linear PCM. */

--- a/src/svx.c
+++ b/src/svx.c
@@ -88,7 +88,7 @@ svx_open	(SF_PRIVATE *psf)
 
 		psf->endian = SF_ENDIAN_BIG ;			/* All SVX files are big endian. */
 
-		psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+		psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 		if (psf->blockwidth)
 			psf->sf.frames = psf->datalength / psf->blockwidth ;
 
@@ -355,7 +355,7 @@ svx_write_header (SF_PRIVATE *psf, int calc_length)
 		if (psf->dataend)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
-		psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+		psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	psf->header.ptr [0] = 0 ;

--- a/src/voc.c
+++ b/src/voc.c
@@ -126,7 +126,7 @@ voc_open	(SF_PRIVATE *psf)
 		psf->write_header = voc_write_header ;
 		} ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	psf->container_close = voc_close ;
 
@@ -431,7 +431,7 @@ voc_write_header (SF_PRIVATE *psf, int calc_length)
 		if (psf->dataend)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
-		psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+		psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	subformat = SF_CODEC (psf->sf.format) ;

--- a/src/w64.c
+++ b/src/w64.c
@@ -145,7 +145,7 @@ w64_open	(SF_PRIVATE *psf)
 
 		psf->endian = SF_ENDIAN_LITTLE ;		/* All W64 files are little endian. */
 
-		psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+		psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 		if (subformat == SF_FORMAT_IMA_ADPCM || subformat == SF_FORMAT_MS_ADPCM)
 		{	blockalign = wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
@@ -451,7 +451,7 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
 		if (psf->bytewidth)
-			psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+			psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	/* Reset the current header length to zero. */

--- a/src/wav.c
+++ b/src/wav.c
@@ -191,7 +191,7 @@ wav_open	(SF_PRIVATE *psf)
 		if (format != SF_FORMAT_WAV && format != SF_FORMAT_WAVEX)
 			return	SFE_BAD_OPEN_FORMAT ;
 
-		psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+		psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 		/* RIFF WAVs are little-endian, RIFX WAVs are big-endian, default to little */
 		psf->endian = SF_ENDIAN (psf->sf.format) ;

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -559,14 +559,14 @@ wavlike_analyze (SF_PRIVATE *psf)
 			psf_log_printf (psf, "wavlike_analyze : found format : 0x%X\n", format) ;
 			psf->sf.format = (psf->sf.format & ~SF_FORMAT_SUBMASK) + format ;
 			psf->bytewidth = 4 ;
-			psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+			psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 			break ;
 
 		case SF_FORMAT_PCM_24 :
 			psf_log_printf (psf, "wavlike_analyze : found format : 0x%X\n", format) ;
 			psf->sf.format = (psf->sf.format & ~SF_FORMAT_SUBMASK) + format ;
 			psf->bytewidth = 3 ;
-			psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+			psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 			break ;
 
 		default :

--- a/src/wve.c
+++ b/src/wve.c
@@ -75,7 +75,7 @@ wve_open (SF_PRIVATE *psf)
 		psf->write_header = wve_write_header ;
 		} ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	psf->container_close = wve_close ;
 
@@ -164,7 +164,7 @@ wve_write_header (SF_PRIVATE *psf, int calc_length)
 		if (psf->dataend)
 			psf->datalength -= psf->filelength - psf->dataend ;
 
-		psf->sf.frames = psf->datalength / (psf->bytewidth * psf->sf.channels) ;
+		psf->sf.frames = psf->datalength / ((sf_count_t) psf->bytewidth * psf->sf.channels) ;
 		} ;
 
 	/* Reset the current header length to zero. */

--- a/src/xi.c
+++ b/src/xi.c
@@ -110,7 +110,7 @@ xi_open	(SF_PRIVATE *psf)
 
 	psf->sf.seekable = SF_FALSE ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	switch (subformat)
 	{	case SF_FORMAT_DPCM_8 :		/* 8-bit differential PCM. */
@@ -161,7 +161,7 @@ dpcm_init (SF_PRIVATE *psf)
 {	if (psf->bytewidth == 0 || psf->sf.channels == 0)
 		return SFE_INTERNAL ;
 
-	psf->blockwidth = psf->bytewidth * psf->sf.channels ;
+	psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 	if (psf->file.mode == SFM_READ || psf->file.mode == SFM_RDWR)
 	{	switch (psf->bytewidth)
@@ -476,7 +476,7 @@ xi_read_header (SF_PRIVATE *psf)
 	psf->sf.channels = 1 ; /* Always mono */
 	psf->sf.samplerate = 44100 ; /* Always */
 
-	psf->blockwidth = psf->sf.channels * psf->bytewidth ;
+	psf->blockwidth = (sf_count_t) psf->sf.channels * psf->bytewidth ;
 
 	if (! psf->sf.frames && psf->blockwidth)
 		psf->sf.frames = (psf->filelength - psf->dataoffset) / psf->blockwidth ;


### PR DESCRIPTION
## Summary

PR #979 correctly fixed the signed integer overflow in `psf->blockwidth` computation for `ircam.c`, `mat4.c`, `mat5.c` and `pcm.c` by casting to `sf_count_t` before the multiplication. However, the same class of bug remains in **20 other format handlers** where:

```c
psf->blockwidth = psf->bytewidth * psf->sf.channels ;
```

uses plain `int` arithmetic that overflows when `channels` or `bytewidth` are large (values read from an attacker-controlled audio file).

## Affected Files (29 occurrences across 20 files)

`au.c`, `avr.c`, `caf.c`, `htk.c`, `mpc2k.c`, `nist.c`, `ogg_pcm.c`, `ogg_speex.c`, `paf.c`, `pvf.c`, `raw.c`, `rf64.c`, `sd2.c`, `svx.c`, `voc.c`, `w64.c`, `wav.c`, `wavlike.c`, `wve.c`, `xi.c`

## Fix

Add `(sf_count_t)` cast before each multiplication, exactly matching the pattern established by PR #979:

```c
// Before
psf->blockwidth = psf->bytewidth * psf->sf.channels ;

// After
psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
```

## Testing

- All **143 tests pass** with ASAN enabled (`-fsanitize=address`)
- No functional changes — pure type-safety fix

## References

- Completes the fix started in PR #979
- Related to CVE-2022-33065 (integer overflow class)