### PR TITLE
flac: Fix double free on invalid UTF-8 tag value

### DIFF
--- a/src/flac.c
+++ b/src/flac.c
@@ -646,8 +646,14 @@ flac_write_strings (SF_PRIVATE *psf, FLAC_PRIVATE* pflac)
 
 		value = psf->strings.storage + psf->strings.data [k].offset ;
 
-		FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair (&entry, key, value) ;
-		FLAC__metadata_object_vorbiscomment_append_comment (pflac->metadata, entry, /* copy */ SF_FALSE) ;
+		/*
+		**	entry_from_name_value_pair fails (and leaves entry untouched) when
+		**	value is not valid UTF-8. Without this check the stale entry from the
+		**	previous iteration is appended a second time with copy == false, so
+		**	the same buffer is owned twice and freed twice on cleanup.
+		*/
+		if (FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair (&entry, key, value))
+			FLAC__metadata_object_vorbiscomment_append_comment (pflac->metadata, entry, /* copy */ SF_FALSE) ;
 		} ;
 
 	if (! FLAC__stream_encoder_set_metadata (pflac->fse, &pflac->metadata, 1))


### PR DESCRIPTION
Writing a FLAC tag whose value is not valid UTF-8 frees a heap buffer twice. The allocator aborts at `sf_close()`:

    BUG IN LIBMALLOC: malloc assertion failed   (double free)

`FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair()` returns false and leaves `entry` untouched when the value is not valid UTF-8. `flac_write_strings()` ignored that return and appended `entry` anyway with `copy == false`, so the buffer from the previous successful tag was owned a second time and freed twice on cleanup.

Repro: set a valid title plus a comment containing a stray `0x80` byte, write FLAC, close. The values can come from an untrusted input file, since `sndfile-convert` copies the unvalidated tags from the input straight into the FLAC output.