### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,8 @@
 name: CIFuzz
 on: [pull_request]
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a workflow-level `permissions: { contents: read }` block to the affected workflow(s).

## Why

Without an explicit `permissions:` block, these workflows run with the broad default `GITHUB_TOKEN` scopes. The affected workflows only build, test, and/or fuzz the project — no job writes to the repository, releases, packages, or any other GitHub resource. Restricting the token to `contents: read` follows the principle of least privilege and limits the blast radius if any build/test/fuzz step (or a dependency it pulls in) were compromised. This matches GitHub-recommended and OpenSSF Scorecard "Token-Permissions" hardening guidance.

## Scope

- Additive only: one top-level `permissions` block per affected workflow.
- No change to triggers, jobs, steps, or action versions.
- YAML validated; `git diff --check` clean.

---
*Disclosure: I used AI assistance while preparing this change. The diff is small and I have reviewed it for correctness.*