### PR TITLE
caf, aiff: fix heap buffer over-read in channel map parsing

### DIFF
--- a/src/aiff.c
+++ b/src/aiff.c
@@ -1790,14 +1790,20 @@ aiff_read_chanmap (SF_PRIVATE * psf, unsigned dword)
 		psf_binheader_readf (psf, "j", dword - bytesread) ;
 
 	if (map_info->channel_map != NULL)
-	{	size_t chanmap_size = SF_MIN (psf->sf.channels, layout_tag & 0xffff) * sizeof (psf->channel_map [0]) ;
+	{	/* The channel map buffer must hold psf->sf.channels entries, because that
+		** is how many SFC_GET_CHANNEL_MAP_INFO and the channel-layout matcher read
+		** back. The layout tag may describe fewer channels than the file declares,
+		** so size the allocation by the channel count and copy only the smaller of
+		** the two to avoid a heap over-read. */
+		size_t chanmap_size = (size_t) psf->sf.channels * sizeof (psf->channel_map [0]) ;
+		size_t copy_size = SF_MIN (psf->sf.channels, layout_tag & 0xffff) * sizeof (psf->channel_map [0]) ;
 
 		free (psf->channel_map) ;
 
-		if ((psf->channel_map = malloc (chanmap_size)) == NULL)
+		if ((psf->channel_map = calloc (1, chanmap_size)) == NULL)
 			return SFE_MALLOC_FAILED ;
 
-		memcpy (psf->channel_map, map_info->channel_map, chanmap_size) ;
+		memcpy (psf->channel_map, map_info->channel_map, copy_size) ;
 		} ;
 
 	return 0 ;

--- a/src/caf.c
+++ b/src/caf.c
@@ -811,14 +811,20 @@ caf_read_chanmap (SF_PRIVATE * psf, sf_count_t chunk_size)
 		psf_binheader_readf (psf, "j", chunk_size - bytesread) ;
 
 	if (map_info && map_info->channel_map != NULL)
-	{	size_t chanmap_size = SF_MIN (psf->sf.channels, layout_tag & 0xff) * sizeof (psf->channel_map [0]) ;
+	{	/* The channel map buffer must hold psf->sf.channels entries, because that
+		** is how many SFC_GET_CHANNEL_MAP_INFO and the channel-layout matcher read
+		** back. The layout tag may describe fewer channels than the file declares,
+		** so size the allocation by the channel count and copy only the smaller of
+		** the two to avoid a heap over-read. */
+		size_t chanmap_size = (size_t) psf->sf.channels * sizeof (psf->channel_map [0]) ;
+		size_t copy_size = SF_MIN (psf->sf.channels, layout_tag & 0xff) * sizeof (psf->channel_map [0]) ;
 
 		free (psf->channel_map) ;
 
-		if ((psf->channel_map = malloc (chanmap_size)) == NULL)
+		if ((psf->channel_map = calloc (1, chanmap_size)) == NULL)
 			return SFE_MALLOC_FAILED ;
 
-		memcpy (psf->channel_map, map_info->channel_map, chanmap_size) ;
+		memcpy (psf->channel_map, map_info->channel_map, copy_size) ;
 		} ;
 
 	return 0 ;


### PR DESCRIPTION
## Summary

`caf_read_chanmap()` and `aiff_read_chanmap()` size the `psf->channel_map` allocation by **`SF_MIN (psf->sf.channels, <layout-tag channel count>)`**, but every consumer of `psf->channel_map` reads **`psf->sf.channels`** entries from it. When a file declares more channels in its `desc`/`COMM` chunk than the channel-layout tag describes, the buffer is under-allocated and reads run past its end.

`src/caf.c`:
```c
size_t chanmap_size = SF_MIN (psf->sf.channels, layout_tag & 0xff) * sizeof (psf->channel_map [0]) ;
psf->channel_map = malloc (chanmap_size) ;
memcpy (psf->channel_map, map_info->channel_map, chanmap_size) ;   // buffer holds only the smaller count
```

The over-read sink is the public API `sf_command (SFC_GET_CHANNEL_MAP_INFO)` (`src/sndfile.c`):
```c
if (data == NULL || datasize != SIGNED_SIZEOF (psf->channel_map [0]) * psf->sf.channels) ...
memcpy (data, psf->channel_map, datasize) ;   // reads sizeof(int) * channels from a shorter buffer
```
`aiff_caf_find_channel_layout_tag()` (used on the write/rewrite path) similarly `memcmp`s `channels` entries.

## Impact

Heap buffer over-read (CWE-125). `psf->sf.channels` is attacker-controlled (validated only `<= SF_MAX_CHANNELS` = 1024) and independent of the layout tag, so a crafted file can leak up to ~4 KB of adjacent heap memory into the caller's buffer via `SFC_GET_CHANNEL_MAP_INFO`. Read-only; no write.

## Reproduction (AddressSanitizer)

A crafted CAF with `desc` `channels_per_frame = 8` and a `chan` chunk carrying the stereo layout tag `(101 << 16) | 2` (2-channel, non-NULL map), then `sf_command (f, SFC_GET_CHANNEL_MAP_INFO, buf, sizeof(int)*8)`:

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 32
  #2 sf_command src/sndfile.c:1431
0 bytes after 8-byte region ... allocated by caf_read_chanmap src/caf.c
```
8-byte allocation (2 channels), 32-byte read (8 channels) → 24-byte over-read. Clean after the fix.

## Fix

Allocate the channel map for the full `psf->sf.channels` count, zero-fill it (`calloc`), and copy only the smaller layout-tag count. Files where the counts already match are unaffected. Applied to both the CAF and AIFF handlers.

---
*Disclosure: I used AI assistance while preparing this change, including the ASan-based reproduction. I have reviewed the patch and the analysis for correctness.*