### PR TITLE
sds: avoid divide-by-zero in sds_byterate for zero-frame files

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -757,7 +757,7 @@ sds_seek (SF_PRIVATE *psf, int mode, sf_count_t seek_from_start)
 static int
 sds_byterate (SF_PRIVATE * psf)
 {
-	if (psf->file.mode == SFM_READ)
+	if (psf->file.mode == SFM_READ && psf->sf.frames > 0)
 		return (psf->datalength * psf->sf.samplerate) / psf->sf.frames ;
 
 	return -1 ;


### PR DESCRIPTION
## Summary

`sds_read_header()` sets `psf->sf.frames` directly from the file's 3-byte data-length field with no lower bound (`src/sds.c`):

```c
data_length = SDS_3BYTE_TO_INT_DECODE (data_length) ;
psf->sf.frames = psds->frames = data_length ;   // can be 0
```

SDS uses a custom codec and never sets `psf->bytewidth`, so `sf_current_byterate()` skips its `if (psf->bytewidth)` fast path and calls `psf->byterate` → `sds_byterate()`:

```c
if (psf->file.mode == SFM_READ)
    return (psf->datalength * psf->sf.samplerate) / psf->sf.frames ;   // frames == 0 -> SIGFPE
```

## Impact

Integer divide-by-zero → `SIGFPE` crash (denial of service) when an application calls the public `sf_current_byterate()` on a crafted `.sds` file whose data-length field decodes to 0.

## Reproduction (AddressSanitizer)

A 21-byte `.sds` with the data-length field set to 0, then `sf_current_byterate(f)`:

```
AddressSanitizer: FPE ... in sds_byterate src/sds.c:761
  #1 sf_current_byterate src/sndfile.c:1656
```
Returns `-1` cleanly after the fix.

## Fix

Guard the division with `psf->sf.frames > 0`, returning `-1` (the same 'unknown' value already used for the write path) otherwise.

---
*Disclosure: I used AI assistance while preparing this change, including the ASan-based reproduction. I have reviewed the patch and the analysis for correctness.*