### PR TITLE
nms_adpcm: Fix out-of-bounds write on short read

### DIFF
--- a/src/nms_adpcm.c
+++ b/src/nms_adpcm.c
@@ -703,7 +703,7 @@ psf_nms_adpcm_decode_block (SF_PRIVATE *psf, NMS_ADPCM_PRIVATE *pnms)
 
 	if ((k = (int) psf_fread (pnms->block, sizeof (short), pnms->shortsperblock, psf)) != pnms->shortsperblock)
 	{	psf_log_printf (psf, "*** Warning : short read (%d != %d).\n", k, pnms->shortsperblock) ;
-		memset (pnms->block + (k * sizeof (short)), 0, (pnms->shortsperblock - k) * sizeof (short)) ;
+		memset (pnms->block + k, 0, (pnms->shortsperblock - k) * sizeof (short)) ;
 		} ;
 
 	if (CPU_IS_BIG_ENDIAN)


### PR DESCRIPTION
	*** Warning : short read (20 != 41).

pnms->block is `unsigned short *`, so `block + (k * sizeof (short))` steps 2k
elements in, not k. On a partial final block the zero-fill then starts at
block[2k] and runs shortsperblock-k shorts, past block[NMS_BLOCK_SHORTS_32] into
the adjacent samples[]. Reachable from any raw or WAV NMS ADPCM file whose data
length is not a multiple of shortsperblock*2, so the final psf_fread returns
k < shortsperblock.