### PR TITLE
chunk: fix heap buffer overflow in psf_save_write_chunk (#1114)

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -246,6 +246,7 @@ psf_save_write_chunk (WRITE_CHUNKS * pchk, const SF_CHUNK_INFO * chunk_info)
 			return SFE_MALLOC_FAILED ;
 			} else {
 			pchk->chunks = new_chunks;
+			pchk->count = new_count ;
 			} ;
 		} ;
 


### PR DESCRIPTION
Fixes #1114.

## Bug
`psf_save_write_chunk()` (`src/chunk.c`) grows its write-chunk array with `realloc` when full but never updates `pchk->count` with the new capacity. The array keeps reporting its original size, so `pchk->used` eventually indexes past the allocation, corrupting adjacent heap memory. The read-chunk sibling `psf_store_read_chunk()` already updates `count` correctly — the write path just missed it.

## Fix
Set `pchk->count = new_count` after a successful `realloc`, mirroring the read path.

## Verification
- Built with `-fsanitize=address`. Reproducer uses only the public API (`sf_open` SFM_WRITE → 64× `sf_set_chunk` → `sf_close`). **Before:** `AddressSanitizer: heap-buffer-overflow WRITE of size 8 at chunk.c:257`. **After:** writes 64 chunks cleanly, ASan clean.
- `ctest`: **142/142 pass** (incl. `chunk_test_wav`/`caf`/`rf64` and write/read chunk tests) — no regression.
