### PR TITLE
cast to unsigned char before ctype calls on untrusted bytes

### DIFF
--- a/src/id3.c
+++ b/src/id3.c
@@ -119,9 +119,9 @@ id3_process_v2_genre (const char *genre)
 	** We'll just convert the simple case here, strings of the format "(nnn)".
 	*/
 	ptr = genre ;
-	if (ptr [0] == '(' && (c = *++ ptr) && isdigit (c))
+	if (ptr [0] == '(' && (c = *++ ptr) && isdigit ((unsigned char) c))
 	{	num = c - '0' ;
-		while ((c == *++ ptr) && isdigit (c))
+		while ((c == *++ ptr) && isdigit ((unsigned char) c))
 			num = num * 10 + (c - '0') ;
 		if (c == ')' && (c = *++ ptr) == '\0' && num < 256)
 			if ((ptr = id3_lookup_v1_genre (num)))

--- a/src/ogg_vcomment.c
+++ b/src/ogg_vcomment.c
@@ -160,7 +160,7 @@ vorbiscomment_read_tags (SF_PRIVATE *psf, ogg_packet *packet, vorbiscomment_iden
 		for (c = tag ; *c ; c++)
 		{	if (*c == '=')
 				break ;
-			*c = toupper (*c) ;
+			*c = toupper ((unsigned char) *c) ;
 			} ;
 		if (!c)
 		{	psf_log_printf (psf, "Malformed Vorbis comment, no '=' found.\n") ;

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -2720,7 +2720,7 @@ format_from_extension (SF_PRIVATE *psf)
 	/* Convert everything in the buffer to lower case. */
 	cptr = buffer ;
 	while (*cptr)
-	{	*cptr = tolower (*cptr) ;
+	{	*cptr = tolower ((unsigned char) *cptr) ;
 		cptr ++ ;
 		} ;
 


### PR DESCRIPTION
isdigit()/toupper()/tolower() are called on a plain char:

    id3.c            isdigit (c)      c     = ID3v2 TCON genre byte
    ogg_vcomment.c   toupper (*c)     *c    = Vorbis comment byte
    sndfile.c        tolower (*cptr)  *cptr = filename extension byte

char is signed on the usual targets, so a byte >= 0x80 coming from a
genre frame, a Vorbis comment tag, or a file extension is negative.
These functions are only defined for arguments representable as unsigned
char or EOF (C11 7.4p1); a negative value indexes the ctype table out of
range on libcs that do not special-case it (the MSVC debug CRT asserts).

Cast the argument to unsigned char at each call site, the same guard
psf_isprint already applies. Plain ASCII input is unaffected.