### PR TITLE
avr: Fix over-read when printing ext/user fields

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -157,7 +157,7 @@ avr_read_header (SF_PRIVATE *psf)
 	psf_binheader_readf (psf, "E222", &hdr.res1, &hdr.res2, &hdr.res3) ;
 	psf_binheader_readf (psf, "bb", hdr.ext, sizeof (hdr.ext), hdr.user, sizeof (hdr.user)) ;
 
-	psf_log_printf (psf, "  Ext         : %s\n  User        : %s\n", hdr.ext, hdr.user) ;
+	psf_log_printf (psf, "  Ext         : %.20s\n  User        : %.64s\n", hdr.ext, hdr.user) ;
 
 	psf->endian = SF_ENDIAN_BIG ;
 


### PR DESCRIPTION
1. avr_read_header fills ext[20] and user[64] with raw file bytes via "b" and never NUL-terminates them.
2. both are passed to psf_log_printf %s, so strlen reads past the field; since user is the last AVR_HEADER member the read runs off the stack struct.
3. any AVR file that fills those fields to their full width triggers it.

Bounded each %s with a precision, which psf_log_printf already supports (strnlen).