### PR TITLE
alac: fix pakt_size + 4 overflow in alac_pakt_read_decode.

### DIFF
--- a/src/alac.c
+++ b/src/alac.c
@@ -823,6 +823,8 @@ alac_pakt_read_decode (SF_PRIVATE * psf, uint32_t UNUSED (pakt_offset))
 	psf->get_chunk_size (psf, chunk_iterator, &chunk_info) ;
 
 	pakt_size = chunk_info.datalen ;
+	if (pakt_size > UINT32_MAX-5 )
+		return NULL;
 	chunk_info.data = pakt_data = malloc (pakt_size + 5) ;
 	if (!chunk_info.data)
 		return NULL ;


### PR DESCRIPTION
The pakt_size value is derived from chunk_info.datalen, which is read directly from the file chunk without any validation. In the vulnerable function, an addition (e.g., pakt_size + 5 or pakt_size + 4) is performed before memory allocation. When pakt_size is close to UINT32_MAX, this addition wraps around.