### PR TITLE
common: Fix out-of-bounds read in psf_strlcpy_crlf

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1526,7 +1526,7 @@ psf_strlcpy_crlf (char *dest, const char *src, size_t destmax, size_t srcmax)
 	const char * srcend = src + srcmax ;
 
 	while (dest < destend && src < srcend)
-	{	if ((src [0] == '\r' && src [1] == '\n') || (src [0] == '\n' && src [1] == '\r'))
+	{	if (src + 1 < srcend && ((src [0] == '\r' && src [1] == '\n') || (src [0] == '\n' && src [1] == '\r')))
 		{	*dest++ = '\r' ;
 			*dest++ = '\n' ;
 			src += 2 ;


### PR DESCRIPTION
AddressSanitizer, converting a WAV with a crafted bext chunk through sndfile-convert:

    ==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
        #0 psf_strlcpy_crlf common.c:1529
        #1 broadcast_var_set broadcast.c:71
        #2 sf_command sndfile.c:1313 (SFC_SET_BROADCAST_INFO)

psf_strlcpy_crlf scans the window [src, src+srcmax) but dereferences src[1] whenever src[0] is a CR or LF to detect a CR/LF pair, so a window ending in a lone CR or LF reads one byte past it. The coding_history passed to SFC_SET_BROADCAST_INFO (and tag_text to SFC_SET_CART_INFO) comes straight from an input file bext/cart chunk, so the over-read is reachable from untrusted input relayed by e.g. sndfile-convert.

Gate the two-byte lookahead on src + 1 < srcend. A trailing lone CR/LF still expands to CRLF via the single-character branches, so valid input is unchanged; test_main (psf_strlcpy_crlf, broadcast_var_set, cart_var_set) and the full ctest suite stay green.