### PR TITLE
ogg_vcomment: fix over-read on comment with no '=' separator

### DIFF
--- a/src/ogg_vcomment.c
+++ b/src/ogg_vcomment.c
@@ -162,7 +162,7 @@ vorbiscomment_read_tags (SF_PRIVATE *psf, ogg_packet *packet, vorbiscomment_iden
 				break ;
 			*c = toupper ((unsigned char) *c) ;
 			} ;
-		if (!c)
+		if (*c != '=')
 		{	psf_log_printf (psf, "Malformed Vorbis comment, no '=' found.\n") ;
 			continue ;
 			} ;


### PR DESCRIPTION
AddressSanitizer, opening an Opus file whose OpusTags carries a comment with no `=` (e.g. the literal `TITLE`):

    READ of size 1019 at 0x619000000980 thread T0
      #1 psf_store_string strings.c:126
      #2 vorbiscomment_read_tags ogg_vcomment.c:171
      #3 ogg_opus_open ogg_opus.c:346
      #4 psf_open_file sndfile.c:3214
    0 bytes after 1024-byte region [...] allocated in vorbiscomment_read_tags ogg_vcomment.c:101

The loop that uppercases a comment name stops at `=`, and `if (!c)` is meant to skip names with no separator. `c` is a pointer into the tag buffer and is never NULL, so that branch is dead: a separator-less name whose uppercased form matches a known field (TITLE, ARTIST, ...) falls through to `psf_store_string (psf, id, c + 1)` with `c` on the terminating NUL, so `c + 1` runs strlen off the end of the buffer. Reachable from any untrusted Opus file. Test `*c` against `=` so the missing-separator case is skipped as intended.