### PR TITLE
id3: fix assignment typo in id3_process_v2_genre()

### DIFF
--- a/src/id3.c
+++ b/src/id3.c
@@ -121,7 +121,7 @@ id3_process_v2_genre (const char *genre)
 	ptr = genre ;
 	if (ptr [0] == '(' && (c = *++ ptr) && isdigit ((unsigned char) c))
 	{	num = c - '0' ;
-		while ((c == *++ ptr) && isdigit ((unsigned char) c))
+		while ((c = *++ ptr) && isdigit ((unsigned char) c))
 			num = num * 10 + (c - '0') ;
 		if (c == ')' && (c = *++ ptr) == '\0' && num < 256)
 			if ((ptr = id3_lookup_v1_genre (num)))


### PR DESCRIPTION
`id3_process_v2_genre()` in `src/id3.c` is meant to convert an ID3v2
numeric genre reference such as `"(17)"` into the corresponding ID3v1
genre name (e.g. `"Rock"`). The digit-advancing loop uses `==`
(comparison) instead of `=` (assignment):

```c
ptr = genre ;
if (ptr [0] == '(' && (c = *++ ptr) && isdigit ((unsigned char) c))
{	num = c - '0' ;
	while ((c == *++ ptr) && isdigit ((unsigned char) c))
		num = num * 10 + (c - '0') ;
	if (c == ')' && (c = *++ ptr) == '\0' && num < 256)
		if ((ptr = id3_lookup_v1_genre (num)))
			return ptr ;
	} ;
```

Because `c ==` never assigns the newly read character, `c` stays
frozen at the first digit for the lifetime of the loop. Two
consequences:

- For multi-digit references like `"(17)"` or `"(127)"`, `num` is
  built from the same first digit over and over instead of the
  actual subsequent digits.
- The terminating check `c == ')'` can never be true, since `c` never
  becomes anything other than a digit character. The loop only stops
  because `ptr` eventually walks past the end of the string, at which
  point `*++ptr` is `'\0'`, `isdigit()` is false, and the function
  falls through to `return genre;` — the raw, unconverted string.

So no numeric ID3v2 genre reference is ever resolved to its genre
name; the raw `"(NNN)"` text is always returned as-is.

The fix restores the intended assignment, mirroring the correct
pattern already used two lines above for the first digit
(`c = *++ ptr`):

```c
while ((c = *++ ptr) && isdigit ((unsigned char) c))
```

Verified by extracting the function logic into a standalone harness
with a stub `id3_lookup_v1_genre()` (17 -> "Rock", 5 -> "Funk", 11 ->
"Country", 127 -> "Special-127") and comparing the original vs. fixed
logic side by side, compiled with `-Wall -Wextra -Werror`: the
original always returns `"(17)"`/`"(5)"`/`"(11)"`/`"(127)"`
unconverted, while the fixed version correctly resolves all four to
their genre names. Out-of-range (`"(999)"`) and non-numeric
(`"Alternative"`) inputs behave identically before and after the fix,
so this is not expected to introduce any regression. Also compiled
`src/id3.c` itself (via a local CMake configure for `config.h`) with
`-Wall -Wextra -Werror` — clean, no warnings.