### PR TITLE
ircam: use psf_lrintf when reading samplerate

### DIFF
--- a/src/ircam.c
+++ b/src/ircam.c
@@ -161,7 +161,7 @@ ircam_read_header	(SF_PRIVATE *psf)
 
 	psf_log_printf (psf, "marker: 0x%X\n", marker) ;
 
-	psf->sf.samplerate = (int) samplerate ;
+	psf->sf.samplerate = psf_lrintf (samplerate) ;
 
 	psf_log_printf (psf,	"  Sample Rate : %d\n"
 							"  Channels    : %d\n"


### PR DESCRIPTION
UBSan, clang -fsanitize=undefined:

    src/ircam.c:164:23: runtime error: 2.14748e+09 is outside the range of representable values of type 'int'

ircam_read_header reads the sample rate as a float straight from the file, then casts it with `(int) samplerate`. A crafted IRCAM header carrying an out-of-range or non-finite value makes that cast undefined. psf_lrintf gives defined behaviour and matches mat4.c/mat5.c, which read a file sample rate the same way; the out-of-range value is then rejected by validate_sfinfo. Found with the ossfuzz harness; all 143 ctest cases still pass.