### PR TITLE
common: Use memcpy for unaligned field stores

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -979,11 +979,42 @@ header_gets (SF_PRIVATE *psf, char *ptr, int bufsize)
 	return k ;
 } /* header_gets */
 
+/*
+** Destination fields passed to psf_binheader_readf() live inside packed
+** on-disk header structs and are not guaranteed to be naturally aligned.
+** Storing through a cast pointer is undefined behaviour and faults on
+** strict-alignment targets, so route every multi-byte store through memcpy().
+*/
+static inline void
+store_uint (void *ptr, unsigned int value)
+{	memcpy (ptr, &value, sizeof (value)) ;
+} /* store_uint */
+
+static inline void
+store_ushort (void *ptr, unsigned short value)
+{	memcpy (ptr, &value, sizeof (value)) ;
+} /* store_ushort */
+
+static inline void
+store_count (void *ptr, sf_count_t value)
+{	memcpy (ptr, &value, sizeof (value)) ;
+} /* store_count */
+
+static inline void
+store_float (void *ptr, float value)
+{	memcpy (ptr, &value, sizeof (value)) ;
+} /* store_float */
+
+static inline void
+store_double (void *ptr, double value)
+{	memcpy (ptr, &value, sizeof (value)) ;
+} /* store_double */
+
 int
 psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 {	va_list			argptr ;
 	sf_count_t		*countptr, countdata ;
-	unsigned char	*ucptr, sixteen_bytes [16] = { 0 } ;
+	unsigned char	sixteen_bytes [16] = { 0 } ;
 	unsigned int 	*intptr, intdata ;
 	unsigned short	*shortptr ;
 	char			*charptr ;
@@ -1015,23 +1046,21 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 
 			case 'm' : /* 4 byte marker value eg 'RIFF' */
 					intptr = va_arg (argptr, unsigned int*) ;
-					*intptr = 0 ;
-					ucptr = (unsigned char*) intptr ;
-					read_bytes = header_read (psf, ucptr, sizeof (int)) ;
-					*intptr = GET_MARKER (ucptr) ;
+					store_uint (intptr, 0) ;
+					read_bytes = header_read (psf, sixteen_bytes, sizeof (int)) ;
+					store_uint (intptr, GET_MARKER (sixteen_bytes)) ;
 					break ;
 
 			case 'h' :
 					intptr = va_arg (argptr, unsigned int*) ;
-					*intptr = 0 ;
-					ucptr = (unsigned char*) intptr ;
+					store_uint (intptr, 0) ;
 					read_bytes = header_read (psf, sixteen_bytes, sizeof (sixteen_bytes)) ;
 					{	int k ;
 						intdata = 0 ;
 						for (k = 0 ; k < 16 ; k++)
 							intdata ^= sixteen_bytes [k] << k ;
 						}
-					*intptr = intdata ;
+					store_uint (intptr, intdata) ;
 					break ;
 
 			case '1' :
@@ -1042,65 +1071,63 @@ psf_binheader_readf (SF_PRIVATE *psf, char const *format, ...)
 
 			case '2' : /* 2 byte value with the current endian-ness */
 					shortptr = va_arg (argptr, unsigned short*) ;
-					*shortptr = 0 ;
-					ucptr = (unsigned char*) shortptr ;
-					read_bytes = header_read (psf, ucptr, sizeof (short)) ;
+					store_ushort (shortptr, 0) ;
+					read_bytes = header_read (psf, sixteen_bytes, sizeof (short)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
-						*shortptr = GET_BE_SHORT (ucptr) ;
+						store_ushort (shortptr, GET_BE_SHORT (sixteen_bytes)) ;
 					else
-						*shortptr = GET_LE_SHORT (ucptr) ;
+						store_ushort (shortptr, GET_LE_SHORT (sixteen_bytes)) ;
 					break ;
 
 			case '3' : /* 3 byte value with the current endian-ness */
 					intptr = va_arg (argptr, unsigned int*) ;
-					*intptr = 0 ;
+					store_uint (intptr, 0) ;
 					read_bytes = header_read (psf, sixteen_bytes, 3) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
-						*intptr = GET_BE_3BYTE (sixteen_bytes) ;
+						store_uint (intptr, GET_BE_3BYTE (sixteen_bytes)) ;
 					else
-						*intptr = GET_LE_3BYTE (sixteen_bytes) ;
+						store_uint (intptr, GET_LE_3BYTE (sixteen_bytes)) ;
 					break ;
 
 			case '4' : /* 4 byte value with the current endian-ness */
 					intptr = va_arg (argptr, unsigned int*) ;
-					*intptr = 0 ;
-					ucptr = (unsigned char*) intptr ;
-					read_bytes = header_read (psf, ucptr, sizeof (int)) ;
+					store_uint (intptr, 0) ;
+					read_bytes = header_read (psf, sixteen_bytes, sizeof (int)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
-						*intptr = psf_get_be32 (ucptr, 0) ;
+						store_uint (intptr, psf_get_be32 (sixteen_bytes, 0)) ;
 					else
-						*intptr = psf_get_le32 (ucptr, 0) ;
+						store_uint (intptr, psf_get_le32 (sixteen_bytes, 0)) ;
 					break ;
 
 			case '8' : /* 8 byte value with the current endian-ness */
 					countptr = va_arg (argptr, sf_count_t *) ;
-					*countptr = 0 ;
+					store_count (countptr, 0) ;
 					read_bytes = header_read (psf, sixteen_bytes, 8) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
 						countdata = psf_get_be64 (sixteen_bytes, 0) ;
 					else
 						countdata = psf_get_le64 (sixteen_bytes, 0) ;
-					*countptr = countdata ;
+					store_count (countptr, countdata) ;
 					break ;
 
 			case 'f' : /* Float conversion */
 					floatptr = va_arg (argptr, float *) ;
-					*floatptr = 0.0 ;
-					read_bytes = header_read (psf, floatptr, sizeof (float)) ;
+					store_float (floatptr, 0.0) ;
+					read_bytes = header_read (psf, sixteen_bytes, sizeof (float)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
-						*floatptr = float32_be_read ((unsigned char*) floatptr) ;
+						store_float (floatptr, float32_be_read (sixteen_bytes)) ;
 					else
-						*floatptr = float32_le_read ((unsigned char*) floatptr) ;
+						store_float (floatptr, float32_le_read (sixteen_bytes)) ;
 					break ;
 
 			case 'd' : /* double conversion */
 					doubleptr = va_arg (argptr, double *) ;
-					*doubleptr = 0.0 ;
-					read_bytes = header_read (psf, doubleptr, sizeof (double)) ;
+					store_double (doubleptr, 0.0) ;
+					read_bytes = header_read (psf, sixteen_bytes, sizeof (double)) ;
 					if (psf->rwf_endian == SF_ENDIAN_BIG)
-						*doubleptr = double64_be_read ((unsigned char*) doubleptr) ;
+						store_double (doubleptr, double64_be_read (sixteen_bytes)) ;
 					else
-						*doubleptr = double64_le_read ((unsigned char*) doubleptr) ;
+						store_double (doubleptr, double64_le_read (sixteen_bytes)) ;
 					break ;
 
 			case 's' :


### PR DESCRIPTION
`psf_binheader_readf()` stores decoded header values through pointers obtained from `va_arg` and cast to a wider type. The destination fields live inside packed on-disk header structs and are not guaranteed to be naturally aligned, so these stores are undefined behaviour — fine on x86, but they fault on strict-alignment targets and UBSan traps them.

Reproducing #1150 with the 44-byte WAV from that issue (`wFormatTag` 0x0055, so `wavlike_read_fmt_chunk()` uses the `"24222"` format string), built with `-fsanitize=alignment`:

```
common.c:1066:6: runtime error: store to misaligned address 0x...be for type
'unsigned int', which requires 4 byte alignment
    #0 psf_binheader_readf common.c:1066
    #1 wavlike_read_fmt_chunk wavlike.c:312
```

#1150 reports this against the `'4'` case, but the same construct is used by every multi-byte specifier (`m`, `h`, `2`, `3`, `4`, `8`, `f`, `d`), so this converts them all rather than just the one path that happens to have a reproducer. `memcpy` imposes no alignment requirement and compiles to the same load/store on targets that allow unaligned access.

`'f'` and `'d'` also read directly into the unaligned destination; they now read into the existing scratch buffer first, as the other cases already do. The single-byte `'1'` case is unchanged since it cannot be misaligned.

### Testing

- The #1150 reproducer no longer trips UBSan under `-fsanitize=alignment -fno-sanitize-recover=alignment`.
- Behaviour on that file is unchanged: both before and after, it is rejected with `Malformed 'fmt ' chunk` — the fix removes the UB without changing parsing.
- Five valid WAVs (1/2 channel, 8/16/24/32-bit, 8 kHz–96 kHz) parse to identical results before and after.
- `ctest`: 143/143 pass.
- `src/common.c` compiles clean with `-Wall -Wextra`.
