### PR TITLE
Compute the header byte rate without overflowing int

### DIFF
--- a/src/rf64.c
+++ b/src/rf64.c
@@ -545,7 +545,7 @@ rf64_write_fmt_chunk (SF_PRIVATE *psf)
 			/* fmt : format, channels, samplerate */
 			psf_binheader_writef (psf, "4224", BHW4 (fmt_size), BHW2 (WAVE_FORMAT_EXTENSIBLE), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 			/*  fmt : bytespersec */
-			psf_binheader_writef (psf, "4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+			psf_binheader_writef (psf, "4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 			/*  fmt : blockalign, bitwidth */
 			psf_binheader_writef (psf, "22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (psf->bytewidth * 8)) ;
 

--- a/src/w64.c
+++ b/src/w64.c
@@ -148,7 +148,7 @@ w64_open	(SF_PRIVATE *psf)
 		psf->blockwidth = (sf_count_t) psf->bytewidth * psf->sf.channels ;
 
 		if (subformat == SF_FORMAT_IMA_ADPCM || subformat == SF_FORMAT_MS_ADPCM)
-		{	blockalign = wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
+		{	blockalign = wavlike_srate2blocksize ((sf_count_t) psf->sf.samplerate * psf->sf.channels) ;
 			framesperblock = -1 ;
 
 			/*
@@ -531,9 +531,9 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 		case SF_FORMAT_IMA_ADPCM :
 					{	int		blockalign, framesperblock, bytespersec ;
 
-						blockalign		= wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
+						blockalign		= wavlike_srate2blocksize ((sf_count_t) psf->sf.samplerate * psf->sf.channels) ;
 						framesperblock	= 2 * (blockalign - 4 * psf->sf.channels) / psf->sf.channels + 1 ;
-						bytespersec		= (psf->sf.samplerate * blockalign) / framesperblock ;
+						bytespersec		= ((sf_count_t) psf->sf.samplerate * blockalign) / framesperblock ;
 
 						/* fmt chunk. */
 						fmt_size = 24 + 2 + 2 + 4 + 4 + 2 + 2 + 2 + 2 ;
@@ -556,9 +556,9 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 		case SF_FORMAT_MS_ADPCM :
 					{	int blockalign, framesperblock, bytespersec, extrabytes ;
 
-						blockalign		= wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
+						blockalign		= wavlike_srate2blocksize ((sf_count_t) psf->sf.samplerate * psf->sf.channels) ;
 						framesperblock	= 2 + 2 * (blockalign - 7 * psf->sf.channels) / psf->sf.channels ;
-						bytespersec		= (psf->sf.samplerate * blockalign) / framesperblock ;
+						bytespersec		= ((sf_count_t) psf->sf.samplerate * blockalign) / framesperblock ;
 
 						/* fmt chunk. */
 						extrabytes	= 2 + 2 + WAVLIKE_MSADPCM_ADAPT_COEFF_COUNT * (2 + 2) ;

--- a/src/w64.c
+++ b/src/w64.c
@@ -476,7 +476,7 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "e8224", BHW8 (fmt_size), BHW2 (WAVE_FORMAT_PCM), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "e4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "e4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth */
 					psf_binheader_writef (psf, "e22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (psf->bytewidth * 8)) ;
 					break ;
@@ -490,7 +490,7 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "e8224", BHW8 (fmt_size), BHW2 (WAVE_FORMAT_IEEE_FLOAT), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "e4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "e4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth */
 					psf_binheader_writef (psf, "e22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (psf->bytewidth * 8)) ;
 
@@ -505,7 +505,7 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "e8224", BHW8 (fmt_size), BHW2 (WAVE_FORMAT_MULAW), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "e4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "e4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth */
 					psf_binheader_writef (psf, "e22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (8)) ;
 
@@ -520,7 +520,7 @@ w64_write_header (SF_PRIVATE *psf, int calc_length)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "e8224", BHW8 (fmt_size), BHW2 (WAVE_FORMAT_ALAW), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "e4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "e4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth */
 					psf_binheader_writef (psf, "e22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (8)) ;
 

--- a/src/wav.c
+++ b/src/wav.c
@@ -797,7 +797,7 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "4224", BHW4 (fmt_size), BHW2 (WAVE_FORMAT_PCM), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth */
 					psf_binheader_writef (psf, "22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (psf->bytewidth * 8)) ;
 					break ;
@@ -809,7 +809,7 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "4224", BHW4 (fmt_size), BHW2 (WAVE_FORMAT_IEEE_FLOAT), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth */
 					psf_binheader_writef (psf, "22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (psf->bytewidth * 8)) ;
 
@@ -822,7 +822,7 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "4224", BHW4 (fmt_size), BHW2 (WAVE_FORMAT_MULAW), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth, extrabytes */
 					psf_binheader_writef (psf, "222", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (8), BHW2 (0)) ;
 
@@ -835,7 +835,7 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 					/* fmt : format, channels, samplerate */
 					psf_binheader_writef (psf, "4224", BHW4 (fmt_size), BHW2 (WAVE_FORMAT_ALAW), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 					/*  fmt : bytespersec */
-					psf_binheader_writef (psf, "4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+					psf_binheader_writef (psf, "4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 					/*  fmt : blockalign, bitwidth, extrabytes */
 					psf_binheader_writef (psf, "222", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (8), BHW2 (0)) ;
 
@@ -1039,7 +1039,7 @@ wavex_write_fmt_chunk (SF_PRIVATE *psf)
 			/* fmt : format, channels, samplerate */
 			psf_binheader_writef (psf, "4224", BHW4 (fmt_size), BHW2 (WAVE_FORMAT_EXTENSIBLE), BHW2 (psf->sf.channels), BHW4 (psf->sf.samplerate)) ;
 			/*  fmt : bytespersec */
-			psf_binheader_writef (psf, "4", BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
+			psf_binheader_writef (psf, "4", BHW4 ((sf_count_t) psf->sf.samplerate * psf->bytewidth * psf->sf.channels)) ;
 			/*  fmt : blockalign, bitwidth */
 			psf_binheader_writef (psf, "22", BHW2 (psf->bytewidth * psf->sf.channels), BHW2 (psf->bytewidth * 8)) ;
 

--- a/src/wav.c
+++ b/src/wav.c
@@ -216,7 +216,7 @@ wav_open	(SF_PRIVATE *psf)
 #endif
 
 		if (subformat == SF_FORMAT_IMA_ADPCM || subformat == SF_FORMAT_MS_ADPCM)
-		{	blockalign = wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
+		{	blockalign = wavlike_srate2blocksize ((sf_count_t) psf->sf.samplerate * psf->sf.channels) ;
 			framesperblock = -1 ; /* Corrected later. */
 			} ;
 
@@ -846,9 +846,9 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 		case SF_FORMAT_IMA_ADPCM :
 					{	int blockalign, framesperblock, bytespersec ;
 
-						blockalign		= wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
+						blockalign		= wavlike_srate2blocksize ((sf_count_t) psf->sf.samplerate * psf->sf.channels) ;
 						framesperblock	= 2 * (blockalign - 4 * psf->sf.channels) / psf->sf.channels + 1 ;
-						bytespersec		= (psf->sf.samplerate * blockalign) / framesperblock ;
+						bytespersec		= ((sf_count_t) psf->sf.samplerate * blockalign) / framesperblock ;
 
 						/* fmt chunk. */
 						fmt_size = 2 + 2 + 4 + 4 + 2 + 2 + 2 + 2 ;
@@ -867,9 +867,9 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 		case SF_FORMAT_MS_ADPCM :
 					{	int	blockalign, framesperblock, bytespersec, extrabytes ;
 
-						blockalign		= wavlike_srate2blocksize (psf->sf.samplerate * psf->sf.channels) ;
+						blockalign		= wavlike_srate2blocksize ((sf_count_t) psf->sf.samplerate * psf->sf.channels) ;
 						framesperblock	= 2 + 2 * (blockalign - 7 * psf->sf.channels) / psf->sf.channels ;
-						bytespersec		= (psf->sf.samplerate * blockalign) / framesperblock ;
+						bytespersec		= ((sf_count_t) psf->sf.samplerate * blockalign) / framesperblock ;
 
 						/* fmt chunk. */
 						extrabytes	= 2 + 2 + WAVLIKE_MSADPCM_ADAPT_COEFF_COUNT * (2 + 2) ;
@@ -934,7 +934,7 @@ wav_write_fmt_chunk (SF_PRIVATE *psf)
 
 						blockalign		= WAVLIKE_GSM610_BLOCKSIZE ;
 						framesperblock	= WAVLIKE_GSM610_SAMPLES ;
-						bytespersec		= (psf->sf.samplerate * blockalign) / framesperblock ;
+						bytespersec		= ((sf_count_t) psf->sf.samplerate * blockalign) / framesperblock ;
 
 						/* fmt chunk. */
 						fmt_size = 2 + 2 + 4 + 4 + 2 + 2 + 2 + 2 ;

--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -723,7 +723,7 @@ wavlike_format_str (int k)
 } /* wavlike_format_str */
 
 int
-wavlike_srate2blocksize (int srate_chan_product)
+wavlike_srate2blocksize (sf_count_t srate_chan_product)
 {	if (srate_chan_product < 12000)
 		return 256 ;
 	if (srate_chan_product < 23000)

--- a/src/wavlike.h
+++ b/src/wavlike.h
@@ -350,7 +350,7 @@ void	wavlike_msadpcm_write_adapt_coeffs (SF_PRIVATE *psf) ;
 
 char const* wavlike_format_str (int k) ;
 
-int		wavlike_srate2blocksize (int srate_chan_product) ;
+int		wavlike_srate2blocksize (sf_count_t srate_chan_product) ;
 int		wavlike_read_fmt_chunk (SF_PRIVATE *psf, int fmtsize) ;
 void	wavlike_write_guid (SF_PRIVATE *psf, const EXT_SUBFORMAT * subformat) ;
 void	wavlike_analyze (SF_PRIVATE *psf) ;


### PR DESCRIPTION
### What

`wav`, `w64` and `rf64` each write a bytes-per-second header field as

```c
BHW4 (psf->sf.samplerate * psf->bytewidth * psf->sf.channels)
```

All three operands are `int`, and the sample rate comes from the *input* file. Converting a file that declares an implausible rate overflows the multiply, which is undefined:

```
src/wav.c:800:38: runtime error: signed integer overflow:
1543547972 * 2 cannot be represented in type 'int'
    #0 wav_write_fmt_chunk wav.c:800
    #1 wav_write_header wav.c:1185
```

The same input reproduces it in `w64.c:479` and `rf64.c:548`.

Only the writer is affected — `sf_open` on the malformed file is fine — so it takes a conversion to reach, which `sndfile-convert` does. The reproducer is a PAF file declaring a sample rate of 1543547972.

### The change

`BHW4` is `((uint32_t) (x))`, so doing the arithmetic in `sf_count_t` and letting `BHW4` truncate writes **the same four bytes it always did**, while removing the overflow. That is also how `au.c`, `avr.c` and `caf.c` already guard the same shape.

Ten sites, all the identical expression: five in `wav.c`, four in `w64.c`, one in `rf64.c`.

### Verification

| | wav | w64 | rf64 |
|---|---|---|---|
| before | 2 runtime errors | 2 | 2 |
| after | 0 | 0 | 0 |

Reverting just the source change and rebuilding brings all six back, so the result is tied to the change and not to the input.

Ordinary files are unaffected: converting the same source to WAV before and after gives byte-identical output, sha1 `3a3816cf706e4e8bcf4959989b853be3a27dc88d`. Converting every format in my seed corpus to wav/w64/rf64 produces no sanitizer output.

### Two related spots I did not touch

- `sf_current_byterate` (`sndfile.c:1653`) has the same multiply but returns `int`, so what it *should* return for an implausible rate is a design question rather than a cast.
- `wavlike_srate2blocksize` takes an `int`, so its callers can overflow before the call.

Happy to fold either in if you'd like them handled together.

### How it was found

Fuzzing the command line tools — which the OSS-Fuzz harnesses don't cover, since those drive `sf_open`/read rather than `sndfile-convert` — with mutated real audio files, under ASan and UBSan.

I calibrated that setup before trusting it: with a deliberate one-byte over-read injected into `wav_read_header`, ASan reports it through `sndfile-info`, and the report disappears when the injection is removed. Worth mentioning that it did *not* reproduce the `%s` over-read fixed in #1141 — on this build the byte after the struct happens to be zero — so a clean run from it is not evidence about that class.

### Disclosure

Written with Claude Code assisting, under my direction; the commit carries an `Assisted-By` trailer. I verified the before/after myself on macOS/arm64. I did not find an AI policy in the repo — happy to follow one if you have a preference.

X: manuaudiomix
