### PR TITLE
ogg_opus: fix a memory leak in ogg_opus_setup_encoder()

### DIFF
--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -749,8 +749,10 @@ ogg_opus_setup_encoder (SF_PRIVATE *psf, OGG_PRIVATE *odata, OPUS_PRIVATE *oopus
 	oopus->buffersize = (1275 * 3 + 7) * oopus->header.nb_streams ;
 	odata->opacket.packet = malloc (oopus->buffersize) ;
 	odata->opacket.packetno = 2 ;
-	if (odata->opacket.packet == NULL)
+	if (odata->opacket.packet == NULL){
+		free(oopus->buffer);
 		return SFE_MALLOC_FAILED ;
+	}
 
 	oopus->serialno = psf_rand_int32 () ;
 	ogg_stream_init (&odata->ostream, oopus->serialno) ;


### PR DESCRIPTION
If malloc(oopus->buffersize) fails, the function returns SFE_MALLOC_FAILED  but does not free the oopus->buffer already allocated .