### PR TITLE
ogg_opus: fix double free of oopus->buffer on encoder setup failure

### DIFF
--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -749,10 +749,11 @@ ogg_opus_setup_encoder (SF_PRIVATE *psf, OGG_PRIVATE *odata, OPUS_PRIVATE *oopus
 	oopus->buffersize = (1275 * 3 + 7) * oopus->header.nb_streams ;
 	odata->opacket.packet = malloc (oopus->buffersize) ;
 	odata->opacket.packetno = 2 ;
-	if (odata->opacket.packet == NULL){
-		free(oopus->buffer);
+	if (odata->opacket.packet == NULL)
+	{	free (oopus->buffer) ;
+		oopus->buffer = NULL ;
 		return SFE_MALLOC_FAILED ;
-	}
+		} ;
 
 	oopus->serialno = psf_rand_int32 () ;
 	ogg_stream_init (&odata->ostream, oopus->serialno) ;


### PR DESCRIPTION
# ogg_opus: fix double free of `oopus->buffer` on encoder setup failure

## What

Fixes a double free introduced by 8795cc078. `ogg_opus_setup_encoder()` frees
`oopus->buffer` on the packet-allocation failure path without clearing the
pointer, and `ogg_opus_close()` frees it again during cleanup.

## Why

`ogg_opus_open()` registers the cleanup callback before setting up the encoder
(`ogg_opus.c:335`, `:344`), so it is already live when setup fails.

`ogg_opus_setup_encoder()` allocates the sample buffer at `:740`, then the packet
buffer at `:750`. If the second allocation fails, `:753` frees the sample buffer
and returns `SFE_MALLOC_FAILED` with `oopus->buffer` left dangling.

The error reaches `psf_open_file()`, which jumps to `error_exit` unconditionally
(`sndfile.c:3283`) and calls `psf_close()` (`:3370`). That invokes the registered
`psf->codec_close` (`:2968`), i.e. `ogg_opus_close()`, whose `if (oopus->buffer)`
guard at `ogg_opus.c:414` passes on the dangling pointer and frees it a second
time at `:415`.

The earlier failure path is fine - at `:741` the buffer is `NULL`, so the guard
at `:414` correctly skips it. Only `:753` leaves a stale pointer.

The other three sites that free `oopus->buffer` already handle this: `:639` and
`:1021` clear it, `:1078` reassigns it immediately.

## Changes

- `ogg_opus.c:753`: clear `oopus->buffer` after freeing it
- brace style on that branch adjusted to match the surrounding code

This keeps the leak fix from 8795cc078 - the `free()` stays and one line is added
after it. The success path never reaches `:753`, so normal operation is
unchanged.

Guarding in `ogg_opus_close()` instead would put the fix on the wrong side and
diverge from the three sites above.

## Notes

Reproduces without patching anything. `oopus->len` scales with the sample rate
while `oopus->buffersize` scales only with the stream count, so 255 channels at
8000 Hz makes `:740` ask for 163,200 bytes and `:750` for 977,160. Calling
`sf_open()` in `SFM_WRITE` mode under a `RLIMIT_AS` tuned into that ~954 KB
window aborts an unpatched build with `free(): double free detected in tcache 2`.

Low severity, so reporting as a normal bug rather than through security channels