### PR TITLE
Set oopus->buffer to NULL after freeing

### DIFF
--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -750,7 +750,8 @@ ogg_opus_setup_encoder (SF_PRIVATE *psf, OGG_PRIVATE *odata, OPUS_PRIVATE *oopus
 	odata->opacket.packet = malloc (oopus->buffersize) ;
 	odata->opacket.packetno = 2 ;
 	if (odata->opacket.packet == NULL){
-		free(oopus->buffer);
+		free (oopus->buffer) ;
+		oopus->buffer = NULL ;
 		return SFE_MALLOC_FAILED ;
 	}
 


### PR DESCRIPTION
oopus->buffer must be set to null , otherwise ogg_opus_close could cause a double-free .